### PR TITLE
Add incremental training pipeline

### DIFF
--- a/data_factory/data_loader.py
+++ b/data_factory/data_loader.py
@@ -14,7 +14,7 @@ import pickle
 
 
 class PSMSegLoader(object):
-    def __init__(self, data_path, win_size, step, mode="train"):
+    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0):
         self.mode = mode
         self.step = step
         self.win_size = win_size
@@ -33,7 +33,9 @@ class PSMSegLoader(object):
 
         self.test = self.scaler.transform(test_data)
 
-        self.train = data
+        start = int(len(data) * train_start)
+        end = int(len(data) * train_end)
+        self.train = data[start:end]
         self.val = self.test
 
         self.test_labels = pd.read_csv(data_path + '/test_label.csv').values[:, 1:]
@@ -70,7 +72,7 @@ class PSMSegLoader(object):
 
 
 class MSLSegLoader(object):
-    def __init__(self, data_path, win_size, step, mode="train"):
+    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0):
         self.mode = mode
         self.step = step
         self.win_size = win_size
@@ -80,8 +82,9 @@ class MSLSegLoader(object):
         data = self.scaler.transform(data)
         test_data = np.load(data_path + "/MSL_test.npy")
         self.test = self.scaler.transform(test_data)
-
-        self.train = data
+        start = int(len(data) * train_start)
+        end = int(len(data) * train_end)
+        self.train = data[start:end]
         self.val = self.test
         self.test_labels = np.load(data_path + "/MSL_test_label.npy")
         print("test:", self.test.shape)
@@ -114,7 +117,7 @@ class MSLSegLoader(object):
 
 
 class SMAPSegLoader(object):
-    def __init__(self, data_path, win_size, step, mode="train"):
+    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0):
         self.mode = mode
         self.step = step
         self.win_size = win_size
@@ -124,8 +127,9 @@ class SMAPSegLoader(object):
         data = self.scaler.transform(data)
         test_data = np.load(data_path + "/SMAP_test.npy")
         self.test = self.scaler.transform(test_data)
-
-        self.train = data
+        start = int(len(data) * train_start)
+        end = int(len(data) * train_end)
+        self.train = data[start:end]
         self.val = self.test
         self.test_labels = np.load(data_path + "/SMAP_test_label.npy")
         print("test:", self.test.shape)
@@ -158,7 +162,7 @@ class SMAPSegLoader(object):
 
 
 class SMDSegLoader(object):
-    def __init__(self, data_path, win_size, step, mode="train"):
+    def __init__(self, data_path, win_size, step, mode="train", train_start=0.0, train_end=1.0):
         self.mode = mode
         self.step = step
         self.win_size = win_size
@@ -168,7 +172,9 @@ class SMDSegLoader(object):
         data = self.scaler.transform(data)
         test_data = np.load(data_path + "/SMD_test.npy")
         self.test = self.scaler.transform(test_data)
-        self.train = data
+        start = int(len(data) * train_start)
+        end = int(len(data) * train_end)
+        self.train = data[start:end]
         data_len = len(self.train)
         self.val = self.train[(int)(data_len * 0.8):]
         self.test_labels = np.load(data_path + "/SMD_test_label.npy")
@@ -199,15 +205,15 @@ class SMDSegLoader(object):
                 self.test_labels[index // self.step * self.win_size:index // self.step * self.win_size + self.win_size])
 
 
-def get_loader_segment(data_path, batch_size, win_size=100, step=100, mode='train', dataset='KDD'):
+def get_loader_segment(data_path, batch_size, win_size=100, step=100, mode='train', dataset='KDD', train_start=0.0, train_end=1.0):
     if (dataset == 'SMD'):
-        dataset = SMDSegLoader(data_path, win_size, step, mode)
+        dataset = SMDSegLoader(data_path, win_size, step, mode, train_start, train_end)
     elif (dataset == 'MSL'):
-        dataset = MSLSegLoader(data_path, win_size, 1, mode)
+        dataset = MSLSegLoader(data_path, win_size, 1, mode, train_start, train_end)
     elif (dataset == 'SMAP'):
-        dataset = SMAPSegLoader(data_path, win_size, 1, mode)
+        dataset = SMAPSegLoader(data_path, win_size, 1, mode, train_start, train_end)
     elif (dataset == 'PSM'):
-        dataset = PSMSegLoader(data_path, win_size, 1, mode)
+        dataset = PSMSegLoader(data_path, win_size, 1, mode, train_start, train_end)
 
     shuffle = False
     if mode == 'train':

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -1,0 +1,77 @@
+import argparse
+import os
+import subprocess
+
+
+def run_phase(args, tag, start, end, load_model=None):
+    train_cmd = [
+        'python', 'main.py',
+        '--mode', 'train',
+        '--dataset', args.dataset,
+        '--data_path', args.data_path,
+        '--win_size', str(args.win_size),
+        '--input_c', str(args.input_c),
+        '--output_c', str(args.output_c),
+        '--batch_size', str(args.batch_size),
+        '--num_epochs', str(args.num_epochs),
+        '--anormly_ratio', str(args.anormly_ratio),
+        '--model_save_path', args.model_save_path,
+        '--model_tag', tag,
+        '--train_start', str(start),
+        '--train_end', str(end)
+    ]
+    if load_model:
+        train_cmd += ['--load_model', load_model]
+    subprocess.run(train_cmd, check=True)
+
+    test_cmd = [
+        'python', 'main.py',
+        '--mode', 'test',
+        '--dataset', args.dataset,
+        '--data_path', args.data_path,
+        '--win_size', str(args.win_size),
+        '--input_c', str(args.input_c),
+        '--output_c', str(args.output_c),
+        '--batch_size', str(args.batch_size),
+        '--anormly_ratio', str(args.anormly_ratio),
+        '--model_save_path', args.model_save_path,
+        '--model_tag', tag
+    ]
+    subprocess.run(test_cmd, check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dataset', type=str, required=True)
+    parser.add_argument('--data_path', type=str, required=True)
+    parser.add_argument('--win_size', type=int, default=100)
+    parser.add_argument('--input_c', type=int, required=True)
+    parser.add_argument('--output_c', type=int, required=True)
+    parser.add_argument('--batch_size', type=int, default=256)
+    parser.add_argument('--num_epochs', type=int, default=10)
+    parser.add_argument('--anormly_ratio', type=float, default=1.0)
+    parser.add_argument('--model_save_path', type=str, default='checkpoints')
+    args = parser.parse_args()
+
+    os.makedirs(args.model_save_path, exist_ok=True)
+
+    # initial training with first 50%
+    run_phase(args, 'init50', 0.0, 0.5)
+    prev_tag = 'init50'
+
+    # incremental updates
+    start = 0.5
+    for i in range(5):
+        end = start + 0.1
+        tag = f'update_{i+1}'
+        load = os.path.join(args.model_save_path, f'{prev_tag}_checkpoint.pth')
+        run_phase(args, tag, start, end, load)
+        prev_tag = tag
+        start = end
+
+    # full data baseline
+    run_phase(args, 'full_batch', 0.0, 1.0)
+
+
+if __name__ == '__main__':
+    main()

--- a/main.py
+++ b/main.py
@@ -35,7 +35,10 @@ if __name__ == '__main__':
     parser.add_argument('--input_c', type=int, default=38)
     parser.add_argument('--output_c', type=int, default=38)
     parser.add_argument('--batch_size', type=int, default=1024)
-    parser.add_argument('--pretrained_model', type=str, default=None)
+    parser.add_argument('--load_model', type=str, default=None)
+    parser.add_argument('--train_start', type=float, default=0.0)
+    parser.add_argument('--train_end', type=float, default=1.0)
+    parser.add_argument('--model_tag', type=str, default=None)
     parser.add_argument('--dataset', type=str, default='credit')
     parser.add_argument('--mode', type=str, default='train', choices=['train', 'test'])
     parser.add_argument('--data_path', type=str, default='./dataset/creditcard_ts.csv')
@@ -43,6 +46,8 @@ if __name__ == '__main__':
     parser.add_argument('--anormly_ratio', type=float, default=4.00)
 
     config = parser.parse_args()
+    if config.model_tag is None:
+        config.model_tag = config.dataset
 
     args = vars(config)
     print('------------ Options -------------')


### PR DESCRIPTION
## Summary
- support training on partial dataset segments
- load checkpoints for fine-tuning and use custom model tags
- allow specifying data fraction and model tag via CLI
- add incremental_experiment.py to automate fine-tuning in 10% steps

## Testing
- `python -m py_compile incremental_experiment.py main.py solver.py data_factory/data_loader.py`

------
https://chatgpt.com/codex/tasks/task_e_68487609431c8323bbd32f6832e92e2c