### PR TITLE
Print metrics after each incremental training phase

### DIFF
--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -54,9 +54,13 @@ def run_phase(args, tag, start, end, load_model=None):
     ]
     result = subprocess.run(test_cmd, capture_output=True, text=True, check=True)
     metrics = parse_metrics(result.stdout)
+    if metrics:
+        print(
+            f"Performance for {tag} - Accuracy: {metrics['accuracy']:.4f}, "
+            f"Precision: {metrics['precision']:.4f}, Recall: {metrics['recall']:.4f}, "
+            f"F-score: {metrics['f1']:.4f}"
+        )
     return metrics
-  
-    subprocess.run(test_cmd, check=True)
 
 
 def main():
@@ -80,9 +84,6 @@ def main():
     metrics = run_phase(args, 'init50', 0.0, 0.5)
     if metrics:
         results.append((0.5, 'init50', metrics))
-        
-    # initial training with first 50%
-    run_phase(args, 'init50', 0.0, 0.5)
     prev_tag = 'init50'
 
     # incremental updates
@@ -94,7 +95,6 @@ def main():
         metrics = run_phase(args, tag, start, end, load)
         if metrics:
             results.append((end, tag, metrics))
-        run_phase(args, tag, start, end, load)
         prev_tag = tag
         start = end
 
@@ -113,7 +113,6 @@ def main():
         plt.title('Incremental Training Performance')
         plt.grid(True)
         plt.savefig(os.path.join(args.model_save_path, 'incremental_results.png'))
-    run_phase(args, 'full_batch', 0.0, 1.0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- ensure metrics are printed after each incremental phase
- fix duplicate phase execution

## Testing
- `python -m py_compile incremental_experiment.py solver.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68493e4c510883239ae516f88c431b85