### PR TITLE
Centralize KL divergence loss

### DIFF
--- a/model/transformer_vae.py
+++ b/model/transformer_vae.py
@@ -7,17 +7,12 @@ import random
 from .AnomalyTransformer import EncoderLayer, Encoder
 from .attn import AnomalyAttention, AttentionLayer
 from .embed import DataEmbedding
+from utils.utils import my_kl_loss
 
 try:
     import ruptures as rpt
 except ImportError:  # ruptures might not be installed
     rpt = None
-
-
-def my_kl_loss(p, q):
-    res = p * (torch.log(p + 1e-4) - torch.log(q + 1e-4))
-    return torch.mean(torch.sum(res, dim=-1), dim=1)
-
 
 class AnomalyTransformerWithVAE(nn.Module):
     """Anomaly Transformer augmented with a VAE branch."""

--- a/solver.py
+++ b/solver.py
@@ -4,16 +4,10 @@ import torch.nn.functional as F
 import numpy as np
 import os
 import time
-from utils.utils import *
+from utils.utils import my_kl_loss
 from model.AnomalyTransformer import AnomalyTransformer
 from model.transformer_vae import AnomalyTransformerWithVAE, train_model_with_replay
 from data_factory.data_loader import get_loader_segment
-
-
-def my_kl_loss(p, q):
-    res = p * (torch.log(p + 0.0001) - torch.log(q + 0.0001))
-    return torch.mean(torch.sum(res, dim=-1), dim=1)
-
 
 def adjust_learning_rate(optimizer, epoch, lr_):
     lr_adjust = {epoch: lr_ * (0.5 ** ((epoch - 1) // 1))}

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -15,3 +15,24 @@ def to_var(x, volatile=False):
 def mkdir(directory):
     if not os.path.exists(directory):
         os.makedirs(directory)
+
+
+def my_kl_loss(p: torch.Tensor, q: torch.Tensor, eps: float = 1e-4) -> torch.Tensor:
+    """Compute KL divergence used throughout the project.
+
+    Parameters
+    ----------
+    p : torch.Tensor
+        Input probability distribution.
+    q : torch.Tensor
+        Reference probability distribution.
+    eps : float, optional
+        Small constant for numerical stability, by default 1e-4.
+
+    Returns
+    -------
+    torch.Tensor
+        Mean KL divergence across the last dimension and batch.
+    """
+    res = p * (torch.log(p + eps) - torch.log(q + eps))
+    return torch.mean(torch.sum(res, dim=-1), dim=1)


### PR DESCRIPTION
## Summary
- add `my_kl_loss` to `utils/utils.py`
- import the shared loss in `solver.py` and `model/transformer_vae.py`
- remove duplicated implementations

## Testing
- `python -m py_compile solver.py model/transformer_vae.py utils/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_685b9bbec02c83238fda6f08f5797c47