### PR TITLE
Fix indentation error in solver

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -105,7 +105,6 @@ class Solver(object):
                 win_size=self.win_size,
                 enc_in=self.input_c,
                 latent_dim=getattr(self, 'latent_dim', 16),
-                beta=getattr(self, 'beta', 1.0))
                 beta=getattr(self, 'beta', 1.0),
                 replay_size=getattr(self, 'replay_size', 1000))
         else:


### PR DESCRIPTION
## Summary
- remove a duplicated line in `solver.py` causing an unexpected indent

## Testing
- `python -m py_compile solver.py incremental_experiment.py`
- `python main.py --help` *(fails: No module named 'torch')*
- `python incremental_experiment.py --help` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_685baa6fc31c8323825850858f068836