### PR TITLE
Fix anomaly_ratio typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ approach leverages the VAE branch to mitigate concept drift.
 - `--output_c`: number of output channels.
 - `--batch_size`: training batch size (default `256`).
 - `--num_epochs`: training epochs (default `10`).
-- `--anormly_ratio`: anomaly ratio in training set (default `1.0`).
+- `--anomaly_ratio`: anomaly ratio in training set (default `1.0`).
 - `--model_save_path`: directory for checkpoints and results (default
   `checkpoints`).
 - `--model_type`: `transformer` or `transformer_vae` (default

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -26,7 +26,7 @@ def main():
     parser.add_argument('--output_c', type=int, required=True)
     parser.add_argument('--batch_size', type=int, default=256)
     parser.add_argument('--num_epochs', type=int, default=10)
-    parser.add_argument('--anormly_ratio', type=float, default=1.0)
+    parser.add_argument('--anomaly_ratio', type=float, default=1.0)
     parser.add_argument('--model_save_path', type=str, default='checkpoints')
 
     parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     parser.add_argument('--mode', type=str, default='train', choices=['train', 'test'])
     parser.add_argument('--data_path', type=str, default='./dataset/creditcard_ts.csv')
     parser.add_argument('--model_save_path', type=str, default='checkpoints')
-    parser.add_argument('--anormly_ratio', type=float, default=4.00)
+    parser.add_argument('--anomaly_ratio', type=float, default=4.00)
 
     config = parser.parse_args()
     if config.model_tag is None:

--- a/model/transformer_vae.py
+++ b/model/transformer_vae.py
@@ -28,10 +28,7 @@ class AnomalyTransformerWithVAE(nn.Module):
 
     def __init__(self, win_size, enc_in, d_model=512, n_heads=8, e_layers=3,
                  d_ff=512, dropout=0.0, activation='gelu', latent_dim=16,
-
-                 beta=1.0):
-
-                 beta=1.0, replay_size: int = 1000):
+                 beta: float = 1.0, replay_size: int = 1000):
 
         super().__init__()
         self.win_size = win_size

--- a/scripts/MSL.sh
+++ b/scripts/MSL.sh
@@ -1,7 +1,7 @@
 export CUDA_VISIBLE_DEVICES=7
 
-python main.py --anormly_ratio 1 --num_epochs 3   --batch_size 256  --mode train --dataset MSL  --data_path dataset/MSL --input_c 55    --output_c 55
-python main.py --anormly_ratio 1  --num_epochs 10      --batch_size 256     --mode test    --dataset MSL   --data_path dataset/MSL  --input_c 55    --output_c 55  --pretrained_model 20
+python main.py --anomaly_ratio 1 --num_epochs 3   --batch_size 256  --mode train --dataset MSL  --data_path dataset/MSL --input_c 55    --output_c 55
+python main.py --anomaly_ratio 1  --num_epochs 10      --batch_size 256     --mode test    --dataset MSL   --data_path dataset/MSL  --input_c 55    --output_c 55  --pretrained_model 20
 
 
 

--- a/scripts/PSM.sh
+++ b/scripts/PSM.sh
@@ -1,6 +1,6 @@
 export CUDA_VISIBLE_DEVICES=0
 
-python main.py --anormly_ratio 1 --num_epochs 3    --batch_size 256  --mode train --dataset PSM  --data_path dataset/PSM --input_c 25    --output_c 25
-python main.py --anormly_ratio 1  --num_epochs 10       --batch_size 256     --mode test    --dataset PSM   --data_path dataset/PSM  --input_c 25    --output_c 25  --pretrained_model 20
+python main.py --anomaly_ratio 1 --num_epochs 3    --batch_size 256  --mode train --dataset PSM  --data_path dataset/PSM --input_c 25    --output_c 25
+python main.py --anomaly_ratio 1  --num_epochs 10       --batch_size 256     --mode test    --dataset PSM   --data_path dataset/PSM  --input_c 25    --output_c 25  --pretrained_model 20
 
 

--- a/scripts/SMAP.sh
+++ b/scripts/SMAP.sh
@@ -1,7 +1,7 @@
 export CUDA_VISIBLE_DEVICES=0
 
-python main.py --anormly_ratio 1 --num_epochs 3   --batch_size 256  --mode train --dataset SMAP  --data_path dataset/SMAP --input_c 25    --output_c 25
-python main.py --anormly_ratio 1  --num_epochs 10        --batch_size 256     --mode test    --dataset SMAP   --data_path dataset/SMAP  --input_c 25    --output_c 25  --pretrained_model 20
+python main.py --anomaly_ratio 1 --num_epochs 3   --batch_size 256  --mode train --dataset SMAP  --data_path dataset/SMAP --input_c 25    --output_c 25
+python main.py --anomaly_ratio 1  --num_epochs 10        --batch_size 256     --mode test    --dataset SMAP   --data_path dataset/SMAP  --input_c 25    --output_c 25  --pretrained_model 20
 
 
 

--- a/scripts/SMD.sh
+++ b/scripts/SMD.sh
@@ -1,4 +1,4 @@
 export CUDA_VISIBLE_DEVICES=0
 
-python main.py --anormly_ratio 0.5 --num_epochs 10   --batch_size 256  --mode train --dataset SMD  --data_path dataset/SMD   --input_c 38
-python main.py --anormly_ratio 0.5 --num_epochs 10   --batch_size 256     --mode test    --dataset SMD   --data_path dataset/SMD     --input_c 38     --pretrained_model 20
+python main.py --anomaly_ratio 0.5 --num_epochs 10   --batch_size 256  --mode train --dataset SMD  --data_path dataset/SMD   --input_c 38
+python main.py --anomaly_ratio 0.5 --num_epochs 10   --batch_size 256     --mode test    --dataset SMD   --data_path dataset/SMD     --input_c 38     --pretrained_model 20

--- a/scripts/Start.sh
+++ b/scripts/Start.sh
@@ -1,18 +1,18 @@
 export CUDA_VISIBLE_DEVICES=0
 
-python main.py --anormly_ratio 0.5 --num_epochs 10   --batch_size 256  --mode train --dataset SMD  --data_path dataset/SMD   --input_c 38
-python main.py --anormly_ratio 0.5 --num_epochs 10   --batch_size 256     --mode test    --dataset SMD   --data_path dataset/SMD     --input_c 38     --pretrained_model 20
+python main.py --anomaly_ratio 0.5 --num_epochs 10   --batch_size 256  --mode train --dataset SMD  --data_path dataset/SMD   --input_c 38
+python main.py --anomaly_ratio 0.5 --num_epochs 10   --batch_size 256     --mode test    --dataset SMD   --data_path dataset/SMD     --input_c 38     --pretrained_model 20
 
-#python main.py --anormly_ratio 1 --num_epochs 3   --batch_size 256  --mode train --dataset MSL  --data_path dataset/MSL --input_c 55    --output_c 55
-#python main.py --anormly_ratio 1  --num_epochs 10      --batch_size 256     --mode test    --dataset MSL   --data_path dataset/MSL  --input_c 55    --output_c 55  --pretrained_model 20
+#python main.py --anomaly_ratio 1 --num_epochs 3   --batch_size 256  --mode train --dataset MSL  --data_path dataset/MSL --input_c 55    --output_c 55
+#python main.py --anomaly_ratio 1  --num_epochs 10      --batch_size 256     --mode test    --dataset MSL   --data_path dataset/MSL  --input_c 55    --output_c 55  --pretrained_model 20
 
-#python main.py --anormly_ratio 1 --num_epochs 3   --batch_size 256  --mode train --dataset SMAP  --data_path dataset/SMAP --input_c 25    --output_c 25
-#python main.py --anormly_ratio 1  --num_epochs 10        --batch_size 256     --mode test    --dataset SMAP   --data_path dataset/SMAP  --input_c 25    --output_c 25  --pretrained_model 20
+#python main.py --anomaly_ratio 1 --num_epochs 3   --batch_size 256  --mode train --dataset SMAP  --data_path dataset/SMAP --input_c 25    --output_c 25
+#python main.py --anomaly_ratio 1  --num_epochs 10        --batch_size 256     --mode test    --dataset SMAP   --data_path dataset/SMAP  --input_c 25    --output_c 25  --pretrained_model 20
 
-#python main.py --anormly_ratio 0.5 --num_epochs 3    --batch_size 256  --mode train --dataset SWaT  --data_path dataset/SWaT --input_c 51    --output_c 51
-#python main.py --anormly_ratio 0.1  --num_epochs 10        --batch_size 256     --mode test    --dataset SWaT   --data_path dataset/SWaT  --input_c 51    --output_c 51  --pretrained_model 10
+#python main.py --anomaly_ratio 0.5 --num_epochs 3    --batch_size 256  --mode train --dataset SWaT  --data_path dataset/SWaT --input_c 51    --output_c 51
+#python main.py --anomaly_ratio 0.1  --num_epochs 10        --batch_size 256     --mode test    --dataset SWaT   --data_path dataset/SWaT  --input_c 51    --output_c 51  --pretrained_model 10
 
-#python main.py --anormly_ratio 1 --num_epochs 3    --batch_size 256  --mode train --dataset PSM  --data_path dataset/PSM --input_c 25    --output_c 25
-#python main.py --anormly_ratio 1  --num_epochs 10       --batch_size 256     --mode test    --dataset PSM   --data_path dataset/PSM  --input_c 25    --output_c 25  --pretrained_model 20
+#python main.py --anomaly_ratio 1 --num_epochs 3    --batch_size 256  --mode train --dataset PSM  --data_path dataset/PSM --input_c 25    --output_c 25
+#python main.py --anomaly_ratio 1  --num_epochs 10       --batch_size 256     --mode test    --dataset PSM   --data_path dataset/PSM  --input_c 25    --output_c 25  --pretrained_model 20
 
 

--- a/solver.py
+++ b/solver.py
@@ -63,6 +63,7 @@ class Solver(object):
         'latent_dim': 16,
         'beta': 1.0,
         'replay_size': 1000,
+        'anomaly_ratio': 1.0,
     }
 
     def __init__(self, config):
@@ -326,7 +327,7 @@ class Solver(object):
         attens_energy = np.concatenate(attens_energy, axis=0).reshape(-1)
         test_energy = np.array(attens_energy)
         combined_energy = np.concatenate([train_energy, test_energy], axis=0)
-        thresh = np.percentile(combined_energy, 100 - self.anormly_ratio)
+        thresh = np.percentile(combined_energy, 100 - self.anomaly_ratio)
         print("Threshold :", thresh)
 
         # (3) evaluation on the test set


### PR DESCRIPTION
## Summary
- rename `anormly_ratio` option to `anomaly_ratio`
- propagate the rename to scripts and docs
- set default `anomaly_ratio` in `Solver` defaults
- fix constructor typo in `transformer_vae.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bb37d92e083239339ca571f02a6c6