### PR TITLE
Fix incremental experiment parser defaults

### DIFF
--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -26,6 +26,8 @@ def main():
     parser.add_argument('--output_c', type=int, required=True)
     parser.add_argument('--batch_size', type=int, default=256)
     parser.add_argument('--num_epochs', type=int, default=10)
+    parser.add_argument('--lr', type=float, default=1e-4)
+    parser.add_argument('--k', type=int, default=3)
     parser.add_argument('--anomaly_ratio', type=float, default=1.0)
     parser.add_argument('--model_save_path', type=str, default='checkpoints')
 


### PR DESCRIPTION
## Summary
- include default learning rate and loss balancing `k` in the incremental experiment script

## Testing
- `python -m py_compile incremental_experiment.py`

------
https://chatgpt.com/codex/tasks/task_e_685bb5e2a2cc832396a254d8aad15853