### PR TITLE
Fix incremental experiment parser defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,15 @@ approach leverages the VAE branch to mitigate concept drift.
 - `--output_c`: number of output channels.
 - `--batch_size`: training batch size (default `256`).
 - `--num_epochs`: training epochs (default `10`).
+- `--lr`: learning rate for the Adam optimizer (default `1e-4`).
+- `--k`: weighting factor for the association discrepancy losses (default `3`).
 - `--anomaly_ratio`: anomaly ratio in training set (default `1.0`).
 - `--model_save_path`: directory for checkpoints and results (default
   `checkpoints`).
 - `--model_type`: `transformer` or `transformer_vae` (default
   `transformer_vae`).
+
+After training, the script prints the number of updates triggered by CPD events.
 
 ### Example
 

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -7,9 +7,11 @@ from main import main as run_main
 
 
 def train_and_test(args: argparse.Namespace) -> None:
-    """주어진 설정으로 학습 후 평가를 수행한다."""
+    """Train and then evaluate, printing CPD update count."""
     args.mode = "train"
-    run_main(args)
+    solver = run_main(args)
+    if hasattr(solver, "update_count"):
+        print(f"Total CPD updates: {solver.update_count}")
     args.mode = "test"
     args.load_model = os.path.join(
         args.model_save_path, f"{args.model_tag}_checkpoint.pth")
@@ -26,6 +28,8 @@ def main():
     parser.add_argument('--output_c', type=int, required=True)
     parser.add_argument('--batch_size', type=int, default=256)
     parser.add_argument('--num_epochs', type=int, default=10)
+    parser.add_argument('--lr', type=float, default=1e-4)
+    parser.add_argument('--k', type=int, default=3)
     parser.add_argument('--anomaly_ratio', type=float, default=1.0)
     parser.add_argument('--model_save_path', type=str, default='checkpoints')
 


### PR DESCRIPTION
## Summary
- include default learning rate and loss balancing `k` in the incremental experiment script
- document these options in the README
- show how many times CPD-triggered updates occur during training

## Testing
- `python -m py_compile incremental_experiment.py solver.py model/transformer_vae.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_685bb5e2a2cc832396a254d8aad15853