### PR TITLE
Improve CPD handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ approach leverages the VAE branch to mitigate concept drift.
   `transformer_vae`).
 
 After training, the script prints the number of updates triggered by CPD events.
+Install the `ruptures` package (e.g., via `pip install ruptures`) so that these
+change-point detection updates can occur.
 
 ### Example
 


### PR DESCRIPTION
## Summary
- add warnings when ruptures isn't available
- reshape batches in `detect_drift_with_ruptures`
- log warnings when change point detection fails
- document ruptures requirement for continual experiment
- fix replay sampling logic

## Testing
- `python -m py_compile model/transformer_vae.py solver.py incremental_experiment.py`


------
https://chatgpt.com/codex/tasks/task_e_685bbfb59858832382c7199dcf14b5fa