### PR TITLE
Fix CPD update history plotting

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -333,7 +333,6 @@ class Solver(object):
             vali_loss1, vali_loss2 = self.vali(self.test_loader)
             f1 = self.compute_f1()
             self.history.append((self.update_count, vali_loss1, f1))
-            self.history.append((self.update_count, vali_loss1))
 
             print(
                 "Epoch: {0}, Steps: {1} | Train Loss: {2:.7f} Vali Loss: {3:.7f} ".format(


### PR DESCRIPTION
## Summary
- record CPD update count, validation loss and f1 only once per epoch

## Testing
- `python -m py_compile solver.py incremental_experiment.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685bd062276c8323bc8f01b6a38d5908