### PR TITLE
Add ROC AUC visualization and remove val loss plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,10 @@ python incremental_experiment.py \
 ```
 
 Training and evaluation artifacts are saved under `--model_save_path`.
-A figure named `update_performance.png` will visualize validation loss and F1
-score across the number of CPD-triggered updates.
-Metrics are recorded at the end of each epoch, so each point corresponds to the
-update count observed up to that epoch.
-
-A figure named `update_performance.png` will visualize validation loss over the
-number of CPD-triggered updates.
+Two figures, `f1_score.png` and `roc_auc.png`, visualize F1 score and ROC AUC
+across the number of CPD-triggered updates. Metrics are recorded at the end of
+each epoch, so each point corresponds to the update count observed up to that
+epoch.
 
 
 ## Citation


### PR DESCRIPTION
## Summary
- remove validation loss graphs and replace them with F1 score and ROC AUC tracking
- compute ROC AUC alongside F1 during training and testing
- document new plots in README

## Testing
- `python -m py_compile solver.py`


------
https://chatgpt.com/codex/tasks/task_e_685bdc0d8ea8832389a4c298f248c05e