### PR TITLE
Fix compute_metrics with anomaly adjustment

### DIFF
--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -7,15 +7,27 @@ from main import main as run_main
 
 
 def train_and_test(args: argparse.Namespace) -> None:
-    """Train and then evaluate, printing CPD update count."""
+    """Train then evaluate, printing separate summaries."""
     args.mode = "train"
     solver = run_main(args)
+
     if hasattr(solver, "update_count"):
         print(f"Total CPD updates: {solver.update_count}")
+
+    if getattr(solver, "history", None):
+        last_f1 = solver.history[-1][1]
+        last_auc = solver.history[-1][2]
+        print(
+            f"Continual learning - Final F1: {last_f1:.4f}, AUC: {last_auc:.4f}")
+
     args.mode = "test"
     args.load_model = os.path.join(
         args.model_save_path, f"{args.model_tag}_checkpoint.pth")
-    run_main(args)
+    solver.load_model = args.load_model
+    acc, prec, rec, f1, auc = solver.test()
+    print(
+        "Batch evaluation - Accuracy: {:.4f}, Precision: {:.4f}, Recall: {:.4f}, "
+        "F1: {:.4f}, AUC: {:.4f}".format(acc, prec, rec, f1, auc))
 
 
 


### PR DESCRIPTION
## Summary
- adjust prediction post-processing in `compute_metrics` to mirror `test`
- recalc precision/recall/F1/AUC on adjusted predictions
- drop unused accuracy variable
- separate continual learning metrics from batch test in `incremental_experiment`

## Testing
- `python -m py_compile solver.py incremental_experiment.py`


------
https://chatgpt.com/codex/tasks/task_e_685d029a3bf08323abf8983b0bfb8a02