### PR TITLE
Add min_gap filtering for CPD

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ approach leverages the VAE branch to mitigate concept drift.
   `checkpoints`).
 - `--model_type`: `transformer` or `transformer_vae` (default
   `transformer_vae`).
+- `--min_cpd_gap`: minimum separation between detected change points (default
+  `30`).
 
 After training, the script prints the number of updates triggered by CPD events.
 Install the `ruptures` package (e.g., via `pip install ruptures`) so that these

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -44,6 +44,8 @@ def main():
     parser.add_argument('--k', type=int, default=3)
     parser.add_argument('--anomaly_ratio', type=float, default=1.0)
     parser.add_argument('--model_save_path', type=str, default='checkpoints')
+    parser.add_argument('--min_cpd_gap', type=int, default=30,
+                        help='minimum gap between CPD change points')
 
     parser.add_argument(
         '--model_type',

--- a/main.py
+++ b/main.py
@@ -48,6 +48,8 @@ if __name__ == '__main__':
     parser.add_argument('--data_path', type=str, default='./dataset/creditcard_ts.csv')
     parser.add_argument('--model_save_path', type=str, default='checkpoints')
     parser.add_argument('--anomaly_ratio', type=float, default=4.00)
+    parser.add_argument('--min_cpd_gap', type=int, default=30,
+                        help='minimum gap between CPD change points')
 
     config = parser.parse_args()
     if config.model_tag is None:

--- a/solver.py
+++ b/solver.py
@@ -75,6 +75,7 @@ class Solver(object):
         'beta': 1.0,
         'replay_size': 1000,
         'anomaly_ratio': 1.0,
+        'min_cpd_gap': 30,
     }
 
     def __init__(self, config):
@@ -309,7 +310,8 @@ class Solver(object):
                 input = input_data.float().to(self.device)
 
                 if getattr(self, 'model_type', 'transformer') == 'transformer_vae':
-                    loss, updated = train_model_with_replay(self.model, self.optimizer, input)
+                    loss, updated = train_model_with_replay(
+                        self.model, self.optimizer, input, self.min_cpd_gap)
                     loss1_list.append(loss)
                     if updated:
                         self.update_count += 1

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -36,3 +36,29 @@ def my_kl_loss(p: torch.Tensor, q: torch.Tensor, eps: float = 1e-4) -> torch.Ten
     """
     res = p * (torch.log(p + eps) - torch.log(q + eps))
     return torch.mean(torch.sum(res, dim=-1), dim=1)
+
+
+def filter_short_segments(changes: list[int], min_gap: int) -> list[int]:
+    """Remove change points that occur too close together.
+
+    Parameters
+    ----------
+    changes : list[int]
+        Sorted change point indices as returned by ``ruptures``.
+    min_gap : int
+        Minimum number of samples required between consecutive change points.
+
+    Returns
+    -------
+    list[int]
+        Filtered list with short segments removed.
+    """
+
+    if not changes:
+        return changes
+
+    filtered = [changes[0]]
+    for cp in changes[1:]:
+        if cp - filtered[-1] >= min_gap:
+            filtered.append(cp)
+    return filtered


### PR DESCRIPTION
## Summary
- implement `filter_short_segments` utility
- filter CPD results in `detect_drift_with_ruptures`
- expose `min_cpd_gap` option in training scripts and `Solver`
- document new option in README

## Testing
- `python -m py_compile utils/utils.py model/transformer_vae.py solver.py main.py incremental_experiment.py`

------
https://chatgpt.com/codex/tasks/task_e_685d781dda90832391d42d50ef010f20