### PR TITLE
Add replay horizon for VAE latent bank

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ approach leverages the VAE branch to mitigate concept drift.
   `checkpoints`).
 - `--model_type`: `transformer` or `transformer_vae` (default
   `transformer_vae`).
+- `--replay_horizon`: keep latent vectors for at most this many training
+  steps when using the VAE model (default `None`).
 
 After training, the script prints the number of updates triggered by CPD events.
 Install the `ruptures` package (e.g., via `pip install ruptures`) so that these

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -53,6 +53,7 @@ def main():
         help='VAE 브랜치를 사용하려면 transformer_vae 선택')
     parser.add_argument('--latent_dim', type=int, default=16)
     parser.add_argument('--beta', type=float, default=1.0)
+    parser.add_argument('--replay_horizon', type=int, default=None)
     parser.add_argument('--model_tag', type=str, default='dynamic')
 
     args = parser.parse_args()

--- a/main.py
+++ b/main.py
@@ -42,6 +42,7 @@ if __name__ == '__main__':
                         choices=['transformer', 'transformer_vae'])
     parser.add_argument('--latent_dim', type=int, default=16)
     parser.add_argument('--beta', type=float, default=1.0)
+    parser.add_argument('--replay_horizon', type=int, default=None)
     parser.add_argument('--model_tag', type=str, default=None)
     parser.add_argument('--dataset', type=str, default='credit')
     parser.add_argument('--mode', type=str, default='train', choices=['train', 'test'])

--- a/solver.py
+++ b/solver.py
@@ -74,6 +74,7 @@ class Solver(object):
         'latent_dim': 16,
         'beta': 1.0,
         'replay_size': 1000,
+        'replay_horizon': None,
         'anomaly_ratio': 1.0,
     }
 
@@ -120,7 +121,8 @@ class Solver(object):
                 enc_in=self.input_c,
                 latent_dim=getattr(self, 'latent_dim', 16),
                 beta=getattr(self, 'beta', 1.0),
-                replay_size=getattr(self, 'replay_size', 1000))
+                replay_size=getattr(self, 'replay_size', 1000),
+                replay_horizon=getattr(self, 'replay_horizon', None))
         else:
             self.model = AnomalyTransformer(
                 win_size=self.win_size,

--- a/tests/test_z_bank_horizon.py
+++ b/tests/test_z_bank_horizon.py
@@ -1,0 +1,27 @@
+import pytest
+
+# Skip the test if PyTorch is unavailable
+torch = pytest.importorskip("torch")
+
+from model.transformer_vae import AnomalyTransformerWithVAE
+
+
+def test_replay_horizon_pruning():
+    model = AnomalyTransformerWithVAE(
+        win_size=4,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+        replay_size=100,
+        replay_horizon=2,
+    )
+    dummy = torch.zeros(1, 4, 1)
+    for _ in range(5):
+        model(dummy)
+    # ensure purge is triggered by sampling
+    model.generate_replay_samples(1)
+    threshold = model.current_step - model.replay_horizon
+    assert all(ts > threshold for _, ts in model.z_bank)

--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -38,7 +38,7 @@ def _collect_latents(model, loader, n_samples):
 
     if not model.z_bank:
         raise ValueError("z_bank is empty; train the model before calling")
-    replay_latents = torch.stack(model.z_bank).cpu().numpy()
+    replay_latents = torch.stack([z for z, _ in model.z_bank]).cpu().numpy()
     replay_latents = replay_latents[-n_samples:]
 
     return orig_latents, replay_latents


### PR DESCRIPTION
## Summary
- keep timestamps for latent vectors and purge old entries
- allow configuring replay horizon via CLI
- update analysis utilities for new z_bank format
- document new option in README
- test that stale vectors are removed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d781dd8588323be45fd5982e005f4