### PR TITLE
Fix indentation error after merge

### DIFF
--- a/model/transformer_vae.py
+++ b/model/transformer_vae.py
@@ -159,20 +159,19 @@ def train_model_with_replay(
     optimizer: torch.optim.Optimizer,
     current_data: torch.Tensor,
     cpd_penalty: int = 20,
+    min_gap: int = 30,
 ) -> tuple[float, bool]:
-def train_model_with_replay(model: AnomalyTransformerWithVAE,
-                            optimizer: torch.optim.Optimizer,
-                            current_data: torch.Tensor,
-                            min_gap: int = 30) -> tuple[float, bool]:
+    """Train model with replay based on detected concept drift."""
     model.train()
     data = current_data
     drift_detected = False
     if rpt is not None:
         try:
             drift = detect_drift_with_ruptures(
-                current_data.detach().cpu().numpy(), pen=cpd_penalty
+                current_data.detach().cpu().numpy(),
+                pen=cpd_penalty,
+                min_gap=min_gap,
             )
-                current_data.detach().cpu().numpy(), min_gap=min_gap)
         except Exception:
             warnings.warn("Change point detection failed; proceeding without replay")
             drift = False

--- a/solver.py
+++ b/solver.py
@@ -318,8 +318,8 @@ class Solver(object):
                         self.optimizer,
                         input,
                         cpd_penalty=getattr(self, 'cpd_penalty', 20),
+                        min_gap=getattr(self, 'min_cpd_gap', 30),
                     )
-                        self.model, self.optimizer, input, self.min_cpd_gap)
                     loss1_list.append(loss)
                     if updated:
                         self.update_count += 1


### PR DESCRIPTION
## Summary
- remove leftover lines from `train_model_with_replay` call
- consolidate duplicate definitions in `transformer_vae`
- include `min_cpd_gap` when calling replay training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d7a8ece0883239464f0c12e0a0bf1