### PR TITLE
Add CPD visualization demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ qualitatively inspecting continual learning behavior.
 - `visualize_cpd_detection(series, penalty=20, save_path="cpd_detection.png")`
   draws change points detected by `ruptures` on top of a sequence so that you
   can confirm whether CPD corresponds to actual distribution shifts.
+- A quick demo script `scripts/visualize_cpd_demo.py` generates a toy series and
+  saves `cpd_demo.png`, `tsne_demo.png`, and `pca_demo.png` so you can verify
+  that these utilities work without preparing a real dataset.
 
 Directories in the provided `save_path` are created automatically, so you can
 use paths such as `outputs/z_bank_tsne.png` without pre-creating the folder.


### PR DESCRIPTION
## Summary
- add `visualize_cpd_demo.py` that generates synthetic data and plots CPD and latent-space projections
- document demo script in the README

## Testing
- `pytest -q` *(fails: 1 skipped)*
- `python scripts/visualize_cpd_demo.py` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6860274a680c8323b0be785e9ac799ce