### PR TITLE
Improve CPD demo checks and add logging interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ approach leverages the VAE branch to mitigate concept drift.
   steps when using the VAE model (default `None`).
 - `--min_cpd_gap`: minimum separation between detected change points (default
   `30`).
+- `--cpd_log_interval`: evaluate and print metrics only after this many CPD
+  updates (default `20`).
 
 After training, the script prints the number of updates triggered by CPD events.
 Install the `ruptures` package (e.g., via `pip install ruptures`) so that these
@@ -119,6 +121,7 @@ qualitatively inspecting continual learning behavior.
 - A quick demo script `scripts/visualize_cpd_demo.py` generates a toy series and
   saves `cpd_demo.png`, `tsne_demo.png`, and `pca_demo.png` so you can verify
   that these utilities work without preparing a real dataset.
+  This demo requires `numpy`, `scikit-learn`, `matplotlib`, and `ruptures`.
 
 Directories in the provided `save_path` are created automatically, so you can
 use paths such as `outputs/z_bank_tsne.png` without pre-creating the folder.

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -63,6 +63,8 @@ def main():
         default=20,
         help='Penalty value for ruptures change point detection',
     )
+    parser.add_argument('--cpd_log_interval', type=int, default=20,
+                        help='log metrics every N CPD updates')
 
     args = parser.parse_args()
 

--- a/main.py
+++ b/main.py
@@ -57,6 +57,8 @@ if __name__ == '__main__':
     )
     parser.add_argument('--min_cpd_gap', type=int, default=30,
                         help='minimum gap between CPD change points')
+    parser.add_argument('--cpd_log_interval', type=int, default=20,
+                        help='log metrics every N CPD updates')
 
     config = parser.parse_args()
     if config.model_tag is None:

--- a/scripts/visualize_cpd_demo.py
+++ b/scripts/visualize_cpd_demo.py
@@ -1,6 +1,20 @@
 """Demonstrate CPD and latent space visualizations on synthetic data."""
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError as exc:
+    raise SystemExit("numpy is required for this demo: install with 'pip install numpy'") from exc
+
+missing = []
+for _mod in ["sklearn", "matplotlib", "ruptures"]:
+    try:
+        __import__(_mod)
+    except ImportError:
+        missing.append(_mod)
+if missing:
+    raise SystemExit(
+        "Missing required packages: " + ", ".join(missing) + ". Install them with 'pip install " + " ".join(missing) + "'"
+    )
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 


### PR DESCRIPTION
## Summary
- avoid crashing demo when required packages are missing
- add `cpd_log_interval` to control how often metrics are computed after drift updates
- respect this setting in solver's training loop
- expose `--cpd_log_interval` CLI option
- document new option and demo dependencies in README

## Testing
- `pytest -q`
- `python scripts/visualize_cpd_demo.py` *(fails: numpy is required)*

------
https://chatgpt.com/codex/tasks/task_e_68602faae32c83239bcb6fdc153cc274