### PR TITLE
Enhance VAE replay options

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ approach leverages the VAE branch to mitigate concept drift.
   (default `20`). A larger value results in fewer detected drifts.
 - `--replay_horizon`: keep latent vectors for at most this many training
   steps when using the VAE model (default `None`).
+- `--store_mu`: store `(mu, logvar)` pairs instead of sampled `z` for replay.
+- `--freeze_after`: freeze the encoder after this many updates (default `None`).
+- `--ema_decay`: apply EMA to encoder weights with this decay (default `None`).
+- `--decoder_type`: choose decoder architecture: `mlp`, `rnn`, or `attention`.
 - `--min_cpd_gap`: minimum separation between detected change points (default
   `30`).
 - `--cpd_log_interval`: evaluate and print metrics only after this many CPD

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -56,6 +56,15 @@ def main():
     parser.add_argument('--latent_dim', type=int, default=16)
     parser.add_argument('--beta', type=float, default=1.0)
     parser.add_argument('--replay_horizon', type=int, default=None)
+    parser.add_argument('--store_mu', action='store_true',
+                        help='store mu/logvar instead of sampled z')
+    parser.add_argument('--freeze_after', type=int, default=None,
+                        help='freeze encoder after this many steps')
+    parser.add_argument('--ema_decay', type=float, default=None,
+                        help='EMA decay for encoder stabilization')
+    parser.add_argument('--decoder_type', type=str, default='mlp',
+                        choices=['mlp', 'rnn', 'attention'],
+                        help='decoder architecture')
     parser.add_argument('--model_tag', type=str, default='dynamic')
     parser.add_argument(
         '--cpd_penalty',

--- a/solver.py
+++ b/solver.py
@@ -75,6 +75,10 @@ class Solver(object):
         'beta': 1.0,
         'replay_size': 1000,
         'replay_horizon': None,
+        'store_mu': False,
+        'freeze_after': None,
+        'ema_decay': None,
+        'decoder_type': 'mlp',
         'anomaly_ratio': 1.0,
         'cpd_penalty': 20,
         'min_cpd_gap': 30,
@@ -125,7 +129,12 @@ class Solver(object):
                 latent_dim=getattr(self, 'latent_dim', 16),
                 beta=getattr(self, 'beta', 1.0),
                 replay_size=getattr(self, 'replay_size', 1000),
-                replay_horizon=getattr(self, 'replay_horizon', None))
+                replay_horizon=getattr(self, 'replay_horizon', None),
+                store_mu=getattr(self, 'store_mu', False),
+                freeze_after=getattr(self, 'freeze_after', None),
+                ema_decay=getattr(self, 'ema_decay', None),
+                decoder_type=getattr(self, 'decoder_type', 'mlp'),
+            )
         else:
             self.model = AnomalyTransformer(
                 win_size=self.win_size,

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -1,0 +1,57 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from model.transformer_vae import AnomalyTransformerWithVAE, train_model_with_replay
+
+
+def test_store_mu_deterministic_replay():
+    model = AnomalyTransformerWithVAE(
+        win_size=4,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+        store_mu=True,
+    )
+    dummy = torch.zeros(1, 4, 1)
+    model(dummy)
+    out1 = model.generate_replay_samples(1, deterministic=True)
+    out2 = model.generate_replay_samples(1, deterministic=True)
+    assert torch.allclose(out1, out2)
+
+
+def test_freeze_encoder():
+    model = AnomalyTransformerWithVAE(
+        win_size=4,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+        freeze_after=1,
+    )
+    dummy = torch.zeros(1, 4, 1)
+    model(dummy)
+    model(dummy)
+    assert not any(p.requires_grad for p in model.encoder.parameters())
+
+
+def test_decoder_types():
+    dummy = torch.zeros(1, 4, 1)
+    for dec in ["mlp", "rnn", "attention"]:
+        model = AnomalyTransformerWithVAE(
+            win_size=4,
+            enc_in=1,
+            d_model=4,
+            n_heads=1,
+            e_layers=1,
+            d_ff=4,
+            latent_dim=2,
+            decoder_type=dec,
+        )
+        out, _, _, _ = model(dummy)
+        assert out.shape == (1, 4, 1)


### PR DESCRIPTION
## Summary
- support storing `mu`/`logvar` for deterministic replay
- allow freezing or EMA-stabilizing the encoder
- make decoder architecture configurable
- expose new options in solver and CLI
- document additional continual learning arguments
- add tests for new features

## Testing
- `pytest -q` *(fails: 2 skipped due to missing torch)*

------
https://chatgpt.com/codex/tasks/task_e_686030c893308323be1567a004b6516b