### PR TITLE
Add demo requirements and clarify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,13 @@ qualitatively inspecting continual learning behavior.
   can confirm whether CPD corresponds to actual distribution shifts.
 - A quick demo script `scripts/visualize_cpd_demo.py` generates a toy series and
   saves `cpd_demo.png`, `tsne_demo.png`, and `pca_demo.png` so you can verify
-  that these utilities work without preparing a real dataset.
-  This demo requires `numpy`, `scikit-learn`, `matplotlib`, and `ruptures`.
+  that these utilities work without preparing a real dataset. Install the
+  dependencies (`numpy`, `matplotlib`, `scikit-learn`, `ruptures`, and `torch`)
+  listed in `requirements-demo.txt` with
+  ```bash
+  pip install -r requirements-demo.txt
+  ```
+  and then run the demo script.
 
 Directories in the provided `save_path` are created automatically, so you can
 use paths such as `outputs/z_bank_tsne.png` without pre-creating the folder.

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -1,0 +1,5 @@
+numpy
+matplotlib
+scikit-learn
+ruptures
+torch

--- a/scripts/visualize_cpd_demo.py
+++ b/scripts/visualize_cpd_demo.py
@@ -6,7 +6,7 @@ except ImportError as exc:
     raise SystemExit("numpy is required for this demo: install with 'pip install numpy'") from exc
 
 missing = []
-for _mod in ["sklearn", "matplotlib", "ruptures"]:
+for _mod in ["torch", "sklearn", "matplotlib", "ruptures"]:
     try:
         __import__(_mod)
     except ImportError:


### PR DESCRIPTION
## Summary
- document dependencies required for the new visualization demo
- add `requirements-demo.txt`
- check for `torch` in `visualize_cpd_demo.py`

## Testing
- `pytest -q`
- `python scripts/visualize_cpd_demo.py` *(fails: numpy missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860340169388323904d76c1641e74d9