### PR TITLE
Add import path fix for visualization demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,18 @@ qualitatively inspecting continual learning behavior.
   can confirm whether CPD corresponds to actual distribution shifts.
 - A quick demo script `scripts/visualize_cpd_demo.py` generates a toy series and
   saves `cpd_demo.png`, `tsne_demo.png`, and `pca_demo.png` so you can verify
-  that these utilities work without preparing a real dataset.
-  This demo requires `numpy`, `scikit-learn`, `matplotlib`, and `ruptures`.
+  that these utilities work without preparing a real dataset. Install the
+  dependencies (`numpy`, `matplotlib`, `scikit-learn`, `ruptures`, and `torch`)
+  listed in `requirements-demo.txt` with
+  ```bash
+  pip install -r requirements-demo.txt
+  ```
+  and then run the demo script from the repository root:
+  ```bash
+  python -m scripts.visualize_cpd_demo
+  ```
+  The script checks for these dependencies and exits with a message if any are
+  missing.
 
 Directories in the provided `save_path` are created automatically, so you can
 use paths such as `outputs/z_bank_tsne.png` without pre-creating the folder.

--- a/requirements-demo.txt
+++ b/requirements-demo.txt
@@ -1,0 +1,5 @@
+numpy
+matplotlib
+scikit-learn
+ruptures
+torch

--- a/scripts/visualize_cpd_demo.py
+++ b/scripts/visualize_cpd_demo.py
@@ -1,19 +1,25 @@
 """Demonstrate CPD and latent space visualizations on synthetic data."""
 
-try:
-    import numpy as np
-except ImportError as exc:
-    raise SystemExit("numpy is required for this demo: install with 'pip install numpy'") from exc
+# Allow running this script directly from ``scripts/`` by adding the project
+# root to ``sys.path`` so that ``utils`` can be imported without a module error.
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
 
 missing = []
-for _mod in ["sklearn", "matplotlib", "ruptures"]:
+for _mod in ["numpy", "torch", "sklearn", "matplotlib", "ruptures"]:
     try:
-        __import__(_mod)
+        globals()[_mod] = __import__(_mod)
     except ImportError:
         missing.append(_mod)
 if missing:
     raise SystemExit(
-        "Missing required packages: " + ", ".join(missing) + ". Install them with 'pip install " + " ".join(missing) + "'"
+        "Missing required packages: "
+        + ", ".join(missing)
+        + ". Install them with 'pip install -r requirements-demo.txt'"
     )
 import torch
 from torch.utils.data import DataLoader, TensorDataset
@@ -49,7 +55,8 @@ def main():
         replay_size=50,
     )
     data = torch.tensor(series, dtype=torch.float32).unsqueeze(0)
-    dataset = TensorDataset(data)
+    labels = torch.zeros(len(data))  # dummy labels required by analysis utils
+    dataset = TensorDataset(data, labels)
     loader = DataLoader(dataset, batch_size=1)
 
     with torch.no_grad():


### PR DESCRIPTION
## Summary
- ensure `visualize_cpd_demo.py` can import project modules when run directly
- document how to run the demo script from the repo root

## Testing
- `pytest -q`
- `python scripts/visualize_cpd_demo.py` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6860340169388323904d76c1641e74d9