### PR TITLE
Fix device mismatch in attention layer

### DIFF
--- a/model/attn.py
+++ b/model/attn.py
@@ -26,7 +26,7 @@ class AnomalyAttention(nn.Module):
         self.output_attention = output_attention
         self.dropout = nn.Dropout(attention_dropout)
         window_size = win_size
-        self.distances = torch.zeros((window_size, window_size)).cuda()
+        self.distances = torch.zeros((window_size, window_size))
         for i in range(window_size):
             for j in range(window_size):
                 self.distances[i][j] = abs(i - j)
@@ -48,7 +48,13 @@ class AnomalyAttention(nn.Module):
         sigma = torch.sigmoid(sigma * 5) + 1e-5
         sigma = torch.pow(3, sigma) - 1
         sigma = sigma.unsqueeze(-1).repeat(1, 1, 1, window_size)  # B H L L
-        prior = self.distances.unsqueeze(0).unsqueeze(0).repeat(sigma.shape[0], sigma.shape[1], 1, 1).cuda()
+        prior = (
+            self.distances
+            .unsqueeze(0)
+            .unsqueeze(0)
+            .repeat(sigma.shape[0], sigma.shape[1], 1, 1)
+            .to(sigma.device)
+        )
         prior = 1.0 / (math.sqrt(2 * math.pi) * sigma) * torch.exp(-prior ** 2 / 2 / (sigma ** 2))
 
         series = self.dropout(torch.softmax(attn, dim=-1))


### PR DESCRIPTION
## Summary
- keep distance matrix on CPU
- send prior to the same device as sigma before computing attention

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860745e6ccc8323b7cdfea95c2797d6