### PR TITLE
Add CPD zoom top-k option

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ approach leverages the VAE branch to mitigate concept drift.
   `30`).
 - `--cpd_log_interval`: evaluate and print metrics only after this many CPD
   updates (default `20`).
+- `--cpd_top_k`: number of zoomed views for CPD visualization (default `3`).
 
 After training, the script prints the number of updates triggered by CPD events.
 Install the `ruptures` package (e.g., via `pip install ruptures`) so that these

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -72,6 +72,8 @@ def main():
         default=20,
         help='Penalty value for ruptures change point detection',
     )
+    parser.add_argument('--cpd_top_k', type=int, default=3,
+                        help='number of zoomed views for CPD visualization')
     parser.add_argument('--cpd_log_interval', type=int, default=20,
                         help='log metrics every N CPD updates')
 

--- a/main.py
+++ b/main.py
@@ -55,6 +55,8 @@ if __name__ == '__main__':
         default=20,
         help='Penalty value for ruptures change point detection',
     )
+    parser.add_argument('--cpd_top_k', type=int, default=3,
+                        help='number of zoomed views for CPD visualization')
     parser.add_argument('--min_cpd_gap', type=int, default=30,
                         help='minimum gap between CPD change points')
     parser.add_argument('--cpd_log_interval', type=int, default=20,

--- a/solver.py
+++ b/solver.py
@@ -83,6 +83,7 @@ class Solver(object):
         'cpd_penalty': 20,
         'min_cpd_gap': 30,
         'cpd_log_interval': 20,
+        'cpd_top_k': 3,
     }
 
     def __init__(self, config):
@@ -452,7 +453,8 @@ class Solver(object):
                 try:
                     series = self.vali_loader.dataset.val[:, 0]
                     cpd_path = os.path.join(path, 'cpd_detection.png')
-                    visualize_cpd_detection(series, save_path=cpd_path)
+                    visualize_cpd_detection(series, save_path=cpd_path,
+                                            top_k=getattr(self, 'cpd_top_k', None))
                 except Exception as e:
                     warnings.warn(f"Failed to visualize CPD: {e}")
 


### PR DESCRIPTION
## Summary
- add `cpd_top_k` argument with default 3
- generate CPD zoomed plots during training using this setting
- document the new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68607da792048323aade34b009aaefef