### PR TITLE
Add extra range zoom for CPD visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ qualitatively inspecting continual learning behavior.
   draws change points detected by `ruptures`. When `penalty` is ``None`` a
   heuristic based on series length is used, and `min_size` enforces a minimum
   gap between change points so the plot remains readable. The helper also
-  accepts `zoom_range` to focus on a specific slice of the sequence and a
+  accepts `zoom_range` to focus on a specific slice of the sequence, a
   `top_k` option that automatically creates additional zoomed-in figures around
-  the most significant change points.
+  the most significant change points, and `extra_zoom_ranges` for arbitrary
+  fixed-range views.
   dataset loader using t-SNE, saving a scatter plot that compares their
   distributions.
 - `visualize_cpd_detection(series, penalty=20, save_path="cpd_detection.png")`

--- a/tests/test_cpd_zoom.py
+++ b/tests/test_cpd_zoom.py
@@ -23,3 +23,11 @@ def test_top_k(tmp_path):
     visualize_cpd_detection(series, penalty=10, save_path=str(out), top_k=1)
     zoom = tmp_path / "cpd_top1.png"
     assert out.exists() and zoom.exists()
+
+
+def test_extra_ranges(tmp_path):
+    series = np.sin(np.linspace(0, 10, 100))
+    out = tmp_path / "cpd.png"
+    visualize_cpd_detection(series, save_path=str(out), extra_zoom_ranges=[(0, 20)])
+    zoom = tmp_path / "cpd_range1.png"
+    assert out.exists() and zoom.exists()

--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -88,7 +88,8 @@ def plot_z_bank_umap(model, loader, n_samples=500, save_path="z_bank_umap.png"):
 
 def visualize_cpd_detection(series, penalty=None, min_size=30,
                             save_path="cpd_detection.png", *,
-                            zoom_range=None, top_k=None, zoom_margin=50):
+                            zoom_range=None, top_k=None, zoom_margin=50,
+                            extra_zoom_ranges=None):
     """Plot change-point locations predicted by ``ruptures``.
 
     Parameters
@@ -111,6 +112,9 @@ def visualize_cpd_detection(series, penalty=None, min_size=30,
     zoom_margin : int, optional
         Half-window size around a selected change point for the zoomed views,
         defaulting to ``50``.
+    extra_zoom_ranges : list of tuple(int, int), optional
+        Additional fixed ranges to visualize. Each range is saved next to
+        ``save_path`` with a ``_range{i}`` suffix.
     """
     if rpt is None:
         raise ImportError("ruptures is required for CPD visualization")
@@ -169,6 +173,15 @@ def visualize_cpd_detection(series, penalty=None, min_size=30,
             start = max(global_cp - zoom_margin, 0)
             end = min(global_cp + zoom_margin, len(orig_series))
             zoom_path = f"{base}_top{i}{ext}"
+            visualize_cpd_detection(
+                orig_series, penalty=penalty, min_size=min_size,
+                save_path=zoom_path, zoom_range=(start, end),
+                top_k=None, zoom_margin=zoom_margin)
+
+    if extra_zoom_ranges:
+        base, ext = os.path.splitext(save_path)
+        for i, (start, end) in enumerate(extra_zoom_ranges, 1):
+            zoom_path = f"{base}_range{i}{ext}"
             visualize_cpd_detection(
                 orig_series, penalty=penalty, min_size=min_size,
                 save_path=zoom_path, zoom_range=(start, end),


### PR DESCRIPTION
## Summary
- extend `visualize_cpd_detection` with an `extra_zoom_ranges` parameter
- document the new option in README
- test that extra zoom plots are produced

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686083174c288323abb5c5d8963b67b7