### PR TITLE
Add replay visualization utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ qualitatively inspecting continual learning behavior.
   missing.
   and then run the demo script.
 
+- Another example, `scripts/visualize_replay_vs_data.py`, compares replayed
+  normal sequences with the original series and saves `replay_vs_actual.png`.
+
 Directories in the provided `save_path` are created automatically, so you can
 use paths such as `outputs/z_bank_tsne.png` without pre-creating the folder.
 

--- a/scripts/visualize_replay_vs_data.py
+++ b/scripts/visualize_replay_vs_data.py
@@ -1,0 +1,69 @@
+"""Demonstrate comparing replayed samples with actual data."""
+
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+missing = []
+for _mod in ["numpy", "torch", "matplotlib"]:
+    try:
+        globals()[_mod] = __import__(_mod)
+    except ImportError:
+        missing.append(_mod)
+if missing:
+    raise SystemExit(
+        "Missing required packages: "
+        + ", ".join(missing)
+        + ". Install them with 'pip install -r requirements-demo.txt'"
+    )
+
+from torch.utils.data import DataLoader, TensorDataset
+
+from utils.analysis_tools import plot_replay_vs_series
+from model.transformer_vae import AnomalyTransformerWithVAE
+
+
+def create_synthetic_series(n_steps=4000):
+    """Return a toy time series with a distribution shift."""
+    first = np.random.normal(0.0, 1.0, (n_steps // 2, 1))
+    second = np.random.normal(3.0, 1.0, (n_steps - n_steps // 2, 1))
+    return np.concatenate([first, second], axis=0)
+
+
+def main():
+    series = create_synthetic_series()
+    model = AnomalyTransformerWithVAE(
+        win_size=20,
+        enc_in=1,
+        d_model=8,
+        n_heads=1,
+        e_layers=1,
+        d_ff=8,
+        latent_dim=4,
+        replay_size=2000,
+    )
+
+    tensor_series = torch.tensor(series, dtype=torch.float32)
+    windows = [tensor_series[i : i + model.win_size]
+               for i in range(len(tensor_series) - model.win_size + 1)]
+    data = torch.stack(windows)
+    loader = DataLoader(TensorDataset(data, torch.zeros(len(data))), batch_size=16)
+
+    with torch.no_grad():
+        for batch, _ in loader:
+            model(batch)
+
+    plot_replay_vs_series(
+        model,
+        series.squeeze(),
+        start=0,
+        end=4000,
+        save_path="replay_vs_actual.png",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_replay_plot.py
+++ b/tests/test_replay_plot.py
@@ -1,0 +1,34 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
+
+from utils.analysis_tools import plot_replay_vs_series
+from model.transformer_vae import AnomalyTransformerWithVAE
+
+
+def test_plot_replay_vs_series(tmp_path):
+    series = np.sin(np.linspace(0, 3.14, 40))
+    model = AnomalyTransformerWithVAE(
+        win_size=10,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+        replay_size=100,
+    )
+    tensor_series = torch.tensor(series, dtype=torch.float32).unsqueeze(-1)
+    windows = [tensor_series[i : i + model.win_size] for i in range(len(series) - model.win_size + 1)]
+    data = torch.stack(windows)
+    loader = torch.utils.data.DataLoader(
+        torch.utils.data.TensorDataset(data, torch.zeros(len(data))), batch_size=1
+    )
+    with torch.no_grad():
+        for batch, _ in loader:
+            model(batch)
+    out = tmp_path / "replay.png"
+    plot_replay_vs_series(model, series, end=20, save_path=str(out))
+    assert out.exists() and out.stat().st_size > 0
+


### PR DESCRIPTION
## Summary
- add `plot_replay_vs_series` helper for comparing replayed data to the original series
- demo script `visualize_replay_vs_data.py` shows how to use the helper
- document the new script in README
- test plotting function in `tests/test_replay_plot.py`

## Testing
- `pytest -q` *(tests skipped: torch, numpy etc. not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686102214c2483239b4cfc54dc723fc7