### PR TITLE
Fix numpy import in replay visualization script

### DIFF
--- a/scripts/visualize_replay_vs_data.py
+++ b/scripts/visualize_replay_vs_data.py
@@ -20,6 +20,9 @@ if missing:
         + ". Install them with 'pip install -r requirements-demo.txt'"
     )
 
+import numpy as np
+import torch
+
 from torch.utils.data import DataLoader, TensorDataset
 
 from utils.analysis_tools import plot_replay_vs_series


### PR DESCRIPTION
## Summary
- ensure `numpy` and `torch` are imported in `visualize_replay_vs_data.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861086660e88323ba7f74e32cad16b3