### PR TITLE
Store training windows in z_bank

### DIFF
--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -72,3 +72,18 @@ def test_generate_replay_sequence():
         model(dummy)
     seq = model.generate_replay_sequence(deterministic=True)
     assert seq.shape[0] >= 3
+
+
+def test_z_bank_stores_x():
+    model = AnomalyTransformerWithVAE(
+        win_size=4,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+    )
+    dummy = torch.ones(1, 4, 1)
+    model(dummy)
+    assert torch.equal(model.z_bank[0][0], dummy[0])

--- a/tests/test_z_bank_horizon.py
+++ b/tests/test_z_bank_horizon.py
@@ -24,4 +24,4 @@ def test_replay_horizon_pruning():
     # ensure purge is triggered by sampling
     model.generate_replay_samples(1)
     threshold = model.current_step - model.replay_horizon
-    assert all(ts > threshold for _, ts in model.z_bank)
+    assert all(item[-1] > threshold for item in model.z_bank)

--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -38,7 +38,7 @@ def _collect_latents(model, loader, n_samples):
 
     if not model.z_bank:
         raise ValueError("z_bank is empty; train the model before calling")
-    replay_latents = torch.stack([z for z, _ in model.z_bank]).cpu().numpy()
+    replay_latents = torch.stack([entry[1] for entry in model.z_bank]).cpu().numpy()
     replay_latents = replay_latents[-n_samples:]
 
     return orig_latents, replay_latents


### PR DESCRIPTION
## Summary
- adjust `z_bank` entries to keep `(x, z, step)` tuples
- update replay generation utilities and visualization tools
- tweak tests for new structure and add a check ensuring `x` is stored

## Testing
- `pytest -q` *(fails: 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686115e2fa008323a82d80620865ccfa