### PR TITLE
Fix replay plotting and remove warnings

### DIFF
--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -23,18 +23,23 @@ def train_and_test(args: argparse.Namespace) -> None:
 
     if args.replay_plot:
         try:
-            ds=solver.train_loader.dataset
-            series=getattr(ds, "train", None)
-            if series is not None:
-                series=series[:, 0]
-                plot_replay_vs_series(
-                    solver.model,
-                    series,
-                    start=0,
-                    end=len(series),
-                    save_path=args.replay_plot,
-                    ordered=True,
-                )
+            ds = solver.train_loader.dataset
+            series = getattr(ds, "train", None)
+            if series is None:
+                raise AttributeError("training dataset does not expose 'train'")
+            if not getattr(solver.model, "z_bank", []):
+                raise ValueError("z_bank is empty; the model saw no training data")
+
+            series = series[:, 0]
+            plot_replay_vs_series(
+                solver.model,
+                series,
+                start=0,
+                end=len(series),
+                save_path=args.replay_plot,
+                ordered=True,
+            )
+            print(f"Replay comparison saved to {args.replay_plot}")
         except Exception as exc:
             print(f"Failed to generate replay plot: {exc}")
     args.mode = "test"

--- a/solver.py
+++ b/solver.py
@@ -191,7 +191,8 @@ class Solver(object):
             warnings.warn("scikit-learn is required to compute metrics")
             return float('nan'), float('nan')
 
-        criterion = nn.MSELoss(reduce=False)
+        # use the modern argument name to silence PyTorch deprecation warning
+        criterion = nn.MSELoss(reduction="none")
         temperature = 50
 
         # energies on train set
@@ -467,13 +468,14 @@ class Solver(object):
         ckpt_path = self.load_model
         if ckpt_path is None:
             ckpt_path = os.path.join(str(self.model_save_path), str(self.model_tag) + '_checkpoint.pth')
-        self.model.load_state_dict(torch.load(ckpt_path))
+        # load weights only to avoid warnings on newer PyTorch versions
+        self.model.load_state_dict(torch.load(ckpt_path, weights_only=True))
         self.model.eval()
         temperature = 50
 
         print("======================TEST MODE======================")
 
-        criterion = nn.MSELoss(reduce=False)
+        criterion = nn.MSELoss(reduction="none")
 
         # (1) stastic on the train set
         attens_energy = []


### PR DESCRIPTION
## Summary
- ensure missing training latents cause a helpful error and log success when plotting replay vs actual series
- silence PyTorch deprecation warnings using `reduction="none"`
- avoid torch.load warning by specifying `weights_only=True`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68611a703b388323b4daedb6e2290ae9