### PR TITLE
Fix replay plot path reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ approach leverages the VAE branch to mitigate concept drift.
 - `--cpd_log_interval`: evaluate and print metrics only after this many CPD
   updates (default `20`).
 - `--replay_plot`: optional path for saving a figure comparing replayed samples
-  with the training data.
+  with the training data. A success message with the absolute location is
+  printed after saving.
 - `--cpd_top_k`: number of zoomed views for CPD visualization (default `3`).
 - `--cpd_extra_ranges`: comma-separated `start:end` pairs for fixed CPD zoom
   windows (default `0:4000`).

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -31,15 +31,19 @@ def train_and_test(args: argparse.Namespace) -> None:
                 raise ValueError("z_bank is empty; the model saw no training data")
 
             series = series[:, 0]
+            out_path = os.path.abspath(args.replay_plot)
             plot_replay_vs_series(
                 solver.model,
                 series,
                 start=0,
                 end=len(series),
-                save_path=args.replay_plot,
+                save_path=out_path,
                 ordered=True,
             )
-            print(f"Replay comparison saved to {args.replay_plot}")
+            if os.path.isfile(out_path):
+                print(f"Replay comparison saved to {out_path}")
+            else:
+                print(f"Replay plot failed to save at {out_path}")
         except Exception as exc:
             print(f"Failed to generate replay plot: {exc}")
     args.mode = "test"


### PR DESCRIPTION
## Summary
- ensure `incremental_experiment.py` checks and prints the absolute path for the replay plot
- document the absolute-path message in README

## Testing
- `pytest -q` *(fails: 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68611e10b8788323a3efbcd0c14e8299