### PR TITLE
Improve startup checks for incremental_experiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ Unsupervised detection of anomaly points in time series is a challenging problem
 
 ## Get Started
 
-1. Install Python 3.6, PyTorch >= 1.4.0. 
-(Thanks Élise for the contribution in solving the environment. See this [issue](https://github.com/thuml/Anomaly-Transformer/issues/11) for details.)
+1. Install Python 3.6 and the required packages:
+
+   ```bash
+   pip install -r requirements-demo.txt
+   ```
+
+   This pulls in PyTorch (>=1.4.0) and other optional dependencies.
+   (Thanks Élise for the contribution in solving the environment. See this [issue](https://github.com/thuml/Anomaly-Transformer/issues/11) for details.)
 2. Download data. You can obtain four benchmarks from [Google Cloud](https://drive.google.com/drive/folders/1gisthCoE-RrKJ0j3KPV7xiibhHWT9qRm?usp=sharing). **All the datasets are well pre-processed**. For the SWaT dataset, you can apply for it by following its official tutorial.
 3. Train and evaluate. We provide the experiment scripts of all benchmarks under the folder `./scripts`. You can reproduce the experiment results as follows:
 ```bash

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -3,6 +3,14 @@
 import argparse
 import os
 
+try:
+    import torch  # noqa: F401
+except ModuleNotFoundError as exc:  # pragma: no cover - graceful message
+    raise SystemExit(
+        "PyTorch is required to run this script.\n"
+        "Install dependencies with 'pip install -r requirements-demo.txt'"
+    ) from exc
+
 from main import main as run_main
 from utils.analysis_tools import plot_replay_vs_series
 


### PR DESCRIPTION
## Summary
- show a clear error if PyTorch is missing when running `incremental_experiment.py`
- document installing dependencies with `requirements-demo.txt`

## Testing
- `pytest -q` *(fails: 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6861227c91d0832393b7049069d8ce09