### PR TITLE
Switch to deterministic AE for replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ approach leverages the VAE branch to mitigate concept drift.
 - `--anomaly_ratio`: anomaly ratio in training set (default `1.0`).
 - `--model_save_path`: directory for checkpoints and results (default
   `checkpoints`).
-- `--model_type`: `transformer` or `transformer_vae` (default
-  `transformer_vae`).
+- `--model_type`: `transformer` or `transformer_ae` (default
+  `transformer_ae`).
 - `--cpd_penalty`: penalty used by `ruptures` for change point detection
   (default `20`). A larger value results in fewer detected drifts.
 - `--replay_horizon`: keep latent vectors for at most this many training
@@ -159,7 +159,7 @@ qualitatively inspecting continual learning behavior.
 Directories in the provided `save_path` are created automatically, so you can
 use paths such as `outputs/z_bank_tsne.png` without pre-creating the folder.
 
-When using the VAE-based model (`--model_type transformer_vae`), these
+When using the AE-based model (`--model_type transformer_ae`), these
 visualizations are generated automatically at the end of training and saved
 alongside the metric plots.
 

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -84,9 +84,9 @@ def main():
     parser.add_argument(
         '--model_type',
         type=str,
-        default='transformer_vae',
-        choices=['transformer', 'transformer_vae'],
-        help='VAE 브랜치를 사용하려면 transformer_vae 선택')
+        default='transformer_ae',
+        choices=['transformer', 'transformer_ae'],
+        help='AE 브랜치를 사용하려면 transformer_ae 선택')
     parser.add_argument('--latent_dim', type=int, default=16)
     parser.add_argument('--beta', type=float, default=1.0)
     parser.add_argument('--replay_horizon', type=int, default=None)

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
     parser.add_argument('--train_start', type=float, default=0.0)
     parser.add_argument('--train_end', type=float, default=1.0)
     parser.add_argument('--model_type', type=str, default='transformer',
-                        choices=['transformer', 'transformer_vae'])
+                        choices=['transformer', 'transformer_ae'])
     parser.add_argument('--latent_dim', type=int, default=16)
     parser.add_argument('--beta', type=float, default=1.0)
     parser.add_argument('--replay_horizon', type=int, default=None)

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,1 +1,1 @@
-from .transformer_vae import AnomalyTransformerWithVAE, detect_drift_with_ruptures, train_model_with_replay
+from .transformer_ae import AnomalyTransformerAE, detect_drift_with_ruptures, train_model_with_replay

--- a/scripts/visualize_cpd_demo.py
+++ b/scripts/visualize_cpd_demo.py
@@ -30,7 +30,7 @@ from utils.analysis_tools import (
     plot_z_bank_tsne,
     plot_z_bank_pca,
 )
-from model.transformer_vae import AnomalyTransformerWithVAE
+from model.transformer_ae import AnomalyTransformerAE
 
 
 def create_synthetic_series(n_steps=400):
@@ -51,7 +51,7 @@ def main():
     )
 
     # minimal model to generate latent vectors
-    model = AnomalyTransformerWithVAE(
+    model = AnomalyTransformerAE(
         win_size=20,
         enc_in=1,
         d_model=8,

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -3,11 +3,11 @@ import pytest
 torch = pytest.importorskip("torch")
 F = torch.nn.functional
 
-from model.transformer_vae import AnomalyTransformerWithVAE, train_model_with_replay
+from model.transformer_ae import AnomalyTransformerAE, train_model_with_replay
 
 
-def test_store_mu_deterministic_replay():
-    model = AnomalyTransformerWithVAE(
+def test_deterministic_replay():
+    model = AnomalyTransformerAE(
         win_size=4,
         enc_in=1,
         d_model=4,
@@ -15,7 +15,6 @@ def test_store_mu_deterministic_replay():
         e_layers=1,
         d_ff=4,
         latent_dim=2,
-        store_mu=True,
     )
     dummy = torch.zeros(1, 4, 1)
     model(dummy)
@@ -25,7 +24,7 @@ def test_store_mu_deterministic_replay():
 
 
 def test_freeze_encoder():
-    model = AnomalyTransformerWithVAE(
+    model = AnomalyTransformerAE(
         win_size=4,
         enc_in=1,
         d_model=4,
@@ -44,7 +43,7 @@ def test_freeze_encoder():
 def test_decoder_types():
     dummy = torch.zeros(1, 4, 1)
     for dec in ["mlp", "rnn", "attention"]:
-        model = AnomalyTransformerWithVAE(
+        model = AnomalyTransformerAE(
             win_size=4,
             enc_in=1,
             d_model=4,
@@ -59,7 +58,7 @@ def test_decoder_types():
 
 
 def test_generate_replay_sequence():
-    model = AnomalyTransformerWithVAE(
+    model = AnomalyTransformerAE(
         win_size=4,
         enc_in=1,
         d_model=4,
@@ -76,7 +75,7 @@ def test_generate_replay_sequence():
 
 
 def test_z_bank_stores_x():
-    model = AnomalyTransformerWithVAE(
+    model = AnomalyTransformerAE(
         win_size=4,
         enc_in=1,
         d_model=4,
@@ -91,7 +90,7 @@ def test_z_bank_stores_x():
 
 
 def test_replay_consistency_loss():
-    model = AnomalyTransformerWithVAE(
+    model = AnomalyTransformerAE(
         win_size=4,
         enc_in=1,
         d_model=4,

--- a/tests/test_replay_plot.py
+++ b/tests/test_replay_plot.py
@@ -4,12 +4,12 @@ np = pytest.importorskip("numpy")
 torch = pytest.importorskip("torch")
 
 from utils.analysis_tools import plot_replay_vs_series
-from model.transformer_vae import AnomalyTransformerWithVAE
+from model.transformer_ae import AnomalyTransformerAE
 
 
 def test_plot_replay_vs_series(tmp_path):
     series = np.sin(np.linspace(0, 3.14, 40))
-    model = AnomalyTransformerWithVAE(
+    model = AnomalyTransformerAE(
         win_size=10,
         enc_in=1,
         d_model=4,

--- a/tests/test_z_bank_horizon.py
+++ b/tests/test_z_bank_horizon.py
@@ -3,11 +3,11 @@ import pytest
 # Skip the test if PyTorch is unavailable
 torch = pytest.importorskip("torch")
 
-from model.transformer_vae import AnomalyTransformerWithVAE
+from model.transformer_ae import AnomalyTransformerAE
 
 
 def test_replay_horizon_pruning():
-    model = AnomalyTransformerWithVAE(
+    model = AnomalyTransformerAE(
         win_size=4,
         enc_in=1,
         d_model=4,

--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -194,7 +194,7 @@ def plot_replay_vs_series(model, series, *, start=0, end=4000,
 
     Parameters
     ----------
-    model : AnomalyTransformerWithVAE
+    model : AnomalyTransformerAE
         Model containing a populated ``z_bank``.
     series : array-like
         1D sequence used during training.


### PR DESCRIPTION
## Summary
- replace VAE implementation with deterministic AE
- update training utilities and docs for AE
- adapt tests and scripts to new autoencoder class
- remove old VAE module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861308376208323ac62e499537a3aed