### PR TITLE
Fix latent plotting and improve F1 graph

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -429,7 +429,7 @@ class Solver(object):
             if self.history:
                 counts, f1s, aucs = zip(*self.history)
                 plt.figure()
-                plt.plot(counts, f1s, marker='o')
+                plt.plot(counts, f1s, marker='o', linestyle='-')
                 plt.xlabel('CPD Updates')
                 plt.ylabel('F1 Score')
                 plt.title('F1 Score over Updates')
@@ -439,7 +439,7 @@ class Solver(object):
                 plt.close()
 
                 plt.figure()
-                plt.plot(counts, aucs, marker='x', color='tab:red')
+                plt.plot(counts, aucs, marker='x', linestyle='-', color='tab:red')
                 plt.xlabel('CPD Updates')
                 plt.ylabel('ROC AUC')
                 plt.title('ROC AUC over Updates')

--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -27,8 +27,15 @@ def _collect_latents(model, loader, n_samples):
             enc = model.embedding(batch)
             enc, _, _, _ = model.encoder(enc)
             pooled = enc.mean(dim=1)
-            mu = model.fc_mu(pooled)
-        orig_latents.append(mu.cpu())
+            if hasattr(model, "fc_mu"):
+                lat = model.fc_mu(pooled)
+            elif hasattr(model, "fc_latent"):
+                lat = model.fc_latent(pooled)
+            else:
+                raise AttributeError(
+                    "Model does not expose a latent projection via `fc_mu` or `fc_latent`"
+                )
+        orig_latents.append(lat.cpu())
         seen += len(batch)
         if seen >= n_samples:
             break


### PR DESCRIPTION
## Summary
- fix latent collection in analysis tools for models without `fc_mu`
- draw lines between F1/AUC points in solver plots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861364edd488323a07a247aec80e375