### PR TITLE
Implement timewise latents and replay memory changes

### DIFF
--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -86,7 +86,7 @@ def test_z_bank_stores_x():
     )
     dummy = torch.ones(1, 4, 1)
     model(dummy)
-    assert torch.equal(model.z_bank[0][0], dummy[0])
+    assert torch.equal(model.z_bank[0]["x"], dummy[0])
 
 
 def test_replay_consistency_loss():
@@ -102,7 +102,7 @@ def test_replay_consistency_loss():
     opt = torch.optim.Adam(model.parameters(), lr=1e-2)
     dummy = torch.ones(1, 4, 1)
     model(dummy)  # populate z_bank
-    before = model.decoder(model.z_bank[0][1].unsqueeze(0)).detach()
+    before = model.decoder(model.z_bank[0]["z"].unsqueeze(0)).detach()
     train_model_with_replay(
         model,
         opt,
@@ -110,6 +110,6 @@ def test_replay_consistency_loss():
         replay_consistency_weight=1.0,
         cpd_penalty=0,
     )
-    after = model.decoder(model.z_bank[0][1].unsqueeze(0))
-    target = model.z_bank[0][0].unsqueeze(0)
+    after = model.decoder(model.z_bank[0]["z"].unsqueeze(0))
+    target = model.z_bank[0]["x"].unsqueeze(0)
     assert F.mse_loss(after, target) < F.mse_loss(before, target)

--- a/tests/test_z_bank_horizon.py
+++ b/tests/test_z_bank_horizon.py
@@ -24,4 +24,4 @@ def test_replay_horizon_pruning():
     # ensure purge is triggered by sampling
     model.generate_replay_samples(1)
     threshold = model.current_step - model.replay_horizon
-    assert all(item[-1] > threshold for item in model.z_bank)
+    assert all(item["step"] > threshold for item in model.z_bank)

--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,0 +1,28 @@
+import numpy as np
+from typing import Sequence
+
+
+def dtw_distance(x: Sequence[float], y: Sequence[float]) -> float:
+    """Compute Dynamic Time Warping distance between two sequences."""
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    n, m = len(x), len(y)
+    dp = np.full((n + 1, m + 1), np.inf)
+    dp[0, 0] = 0.0
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            cost = abs(x[i - 1] - y[j - 1])
+            dp[i, j] = cost + min(dp[i - 1, j], dp[i, j - 1], dp[i - 1, j - 1])
+    return float(dp[n, m])
+
+
+def normality_score(samples: np.ndarray) -> float:
+    """Return a simple normality score based on skew and kurtosis."""
+    if samples.ndim > 1:
+        samples = samples.reshape(-1)
+    mean = np.mean(samples)
+    std = np.std(samples) + 1e-8
+    standardized = (samples - mean) / std
+    skew = np.mean(standardized ** 3)
+    kurt = np.mean(standardized ** 4) - 3
+    return float(abs(skew) + abs(kurt))


### PR DESCRIPTION
## Summary
- adapt decoders to operate on latent sequences instead of vectors
- keep temporal latent representations in the autoencoder
- track replay memory using dictionaries with usage counts
- add Gaussian noise regularization option
- provide DTW and normality score utilities
- update tests for new replay memory format

## Testing
- `pytest -q` *(fails: 4 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68614ec051048323908e2129ba8c0e6e