### PR TITLE
Organize results under dataset and timestamp directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ approach leverages the VAE branch to mitigate concept drift.
 - `--lr`: learning rate for the Adam optimizer (default `1e-4`).
 - `--k`: weighting factor for the association discrepancy losses (default `3`).
 - `--anomaly_ratio`: anomaly ratio in training set (default `1.0`).
-- `--model_save_path`: directory for checkpoints and results (default
-  `checkpoints`).
+- `--model_save_path`: directory for checkpoints and results. By default a
+  timestamped folder is created under `dataset/<dataset>/`.
 - `--model_type`: `transformer` or `transformer_ae` (default
   `transformer_ae`).
 - `--cpd_penalty`: penalty used by `ruptures` for change point detection
@@ -106,6 +106,9 @@ Use `--cpd_penalty` to tune how aggressively change points are detected. Larger
 values, such as `--cpd_penalty 40`, will trigger fewer updates.
 
 Training and evaluation artifacts are saved under `--model_save_path`.
+When left at its default value this directory is automatically created as
+`dataset/<dataset>/<timestamp>` so that results from different runs remain
+organized.
 Two figures, `f1_score.png` and `roc_auc.png`, visualize F1 score and ROC AUC
 across the number of CPD-triggered updates. Starting with this version the
 metrics are evaluated **whenever CPD causes a model update**, so each point

--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+from utils.utils import prepare_experiment_dir, setup_logging
 
 try:
     import torch  # noqa: F401
@@ -131,7 +132,8 @@ def main():
     args = parser.parse_args()
     args.cpd_extra_ranges = _parse_ranges(args.cpd_extra_ranges)
 
-    os.makedirs(args.model_save_path, exist_ok=True)
+    args.model_save_path = prepare_experiment_dir(args.dataset)
+    setup_logging(os.path.join(args.model_save_path, "log.txt"))
 
     train_and_test(args)
 

--- a/main.py
+++ b/main.py
@@ -83,6 +83,9 @@ if __name__ == '__main__':
     config.cpd_extra_ranges = _parse_ranges(config.cpd_extra_ranges)
     if config.model_tag is None:
         config.model_tag = config.dataset
+    # create timestamped directory under dataset/<name>/ for results
+    config.model_save_path = prepare_experiment_dir(config.dataset)
+    setup_logging(os.path.join(config.model_save_path, "log.txt"))
 
     args = vars(config)
     print('------------ Options -------------')

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -4,6 +4,10 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.autograd import Variable
 import numpy as np
+import os
+import logging
+import sys
+from datetime import datetime
 
 
 def to_var(x, volatile=False):
@@ -62,3 +66,37 @@ def filter_short_segments(changes: list[int], min_gap: int) -> list[int]:
         if cp - filtered[-1] >= min_gap:
             filtered.append(cp)
     return filtered
+
+
+def prepare_experiment_dir(dataset: str, root: str = "dataset") -> str:
+    """Create and return a timestamped experiment directory.
+
+    Parameters
+    ----------
+    dataset : str
+        Dataset name supplied via ``--dataset``.
+    root : str, optional
+        Root directory under which results are stored, by default ``"dataset"``.
+
+    Returns
+    -------
+    str
+        Absolute path to the created experiment directory.
+    """
+
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    path = os.path.join(root, dataset.lower(), timestamp)
+    os.makedirs(path, exist_ok=True)
+    return path
+
+
+def setup_logging(log_path: str) -> None:
+    """Configure logging to file and stdout."""
+
+    os.makedirs(os.path.dirname(log_path), exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[logging.FileHandler(log_path), logging.StreamHandler(sys.stdout)],
+    )
+


### PR DESCRIPTION
## Summary
- create helper utilities to generate timestamped result folders and configure logging
- automatically create `dataset/<dataset>/<timestamp>` folder for direct runs of `main.py` and `incremental_experiment.py`
- update README to document new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628cf524148323b06aa024ca5f18c2