### PR TITLE
Fix utils indentation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ approach leverages the VAE branch to mitigate concept drift.
 - `--anomaly_ratio`: anomaly ratio in training set (default `1.0`).
 - `--model_save_path`: directory for checkpoints and results. By default a
   timestamped folder is created under `outputs/<dataset>/`.
-  timestamped folder is created under `dataset/<dataset>/`.
 - `--model_type`: `transformer` or `transformer_ae` (default
   `transformer_ae`).
 - `--cpd_penalty`: penalty used by `ruptures` for change point detection
@@ -109,7 +108,6 @@ values, such as `--cpd_penalty 40`, will trigger fewer updates.
 Training and evaluation artifacts are saved under `--model_save_path`.
 When left at its default value this directory is automatically created as
 `outputs/<dataset>/<timestamp>` so that results from different runs remain
-`dataset/<dataset>/<timestamp>` so that results from different runs remain
 organized.
 Two figures, `f1_score.png` and `roc_auc.png`, visualize F1 score and ROC AUC
 across the number of CPD-triggered updates. Starting with this version the
@@ -158,7 +156,6 @@ qualitatively inspecting continual learning behavior.
   ```
   The script checks for these dependencies and exits with a message if any are
   missing.
-  and then run the demo script.
 
 
 Directories in the provided `save_path` are created automatically, so you can

--- a/main.py
+++ b/main.py
@@ -84,7 +84,6 @@ if __name__ == '__main__':
     if config.model_tag is None:
         config.model_tag = config.dataset
     # create timestamped directory under outputs/<name>/ for results
-    # create timestamped directory under dataset/<name>/ for results
     config.model_save_path = prepare_experiment_dir(config.dataset)
     setup_logging(os.path.join(config.model_save_path, "log.txt"))
 

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -69,7 +69,6 @@ def filter_short_segments(changes: list[int], min_gap: int) -> list[int]:
 
 
 def prepare_experiment_dir(dataset: str, root: str = "outputs") -> str:
-def prepare_experiment_dir(dataset: str, root: str = "dataset") -> str:
     """Create and return a timestamped experiment directory.
 
     Parameters
@@ -78,7 +77,6 @@ def prepare_experiment_dir(dataset: str, root: str = "dataset") -> str:
         Dataset name supplied via ``--dataset``.
     root : str, optional
         Root directory under which results are stored, by default ``"outputs"``.
-        Root directory under which results are stored, by default ``"dataset"``.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- fix duplicated function definition in `utils/utils.py`
- clean up duplicate lines in README and comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68675b1bf5b88323b7ea13bba6b5df1b