### PR TITLE
Add z_bank autoencoder demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ qualitatively inspecting continual learning behavior.
   The script checks for these dependencies and exits with a message if any are
   missing.
 
+- `scripts/zbank_autoencoder_demo.py` illustrates how to train a lightweight
+  autoencoder purely on the latent vectors stored in `z_bank`. After training it
+  generates `recon_tsne.png` and `recon_pca.png` visualizing how well the
+  reconstructions match the original windows. Run the demo with
+
+  ```bash
+  python -m scripts.zbank_autoencoder_demo
+  ```
+
 
 Directories in the provided `save_path` are created automatically, so you can
 use paths such as `outputs/z_bank_tsne.png` without pre-creating the folder.

--- a/scripts/zbank_autoencoder_demo.py
+++ b/scripts/zbank_autoencoder_demo.py
@@ -1,0 +1,59 @@
+"""Demonstrate training an autoencoder on z_bank latents."""
+
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+missing = []
+for _mod in ["numpy", "torch", "sklearn", "matplotlib"]:
+    try:
+        globals()[_mod] = __import__(_mod)
+    except ImportError:
+        missing.append(_mod)
+if missing:
+    raise SystemExit(
+        "Missing required packages: "
+        + ", ".join(missing)
+        + ". Install them with 'pip install -r requirements-demo.txt'"
+    )
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from model.transformer_ae import AnomalyTransformerAE
+from utils.zbank_autoencoder import ZBankAutoencoder, ZBankDataset, train_autoencoder
+from utils.analysis_tools import plot_reconstruction_tsne, plot_reconstruction_pca
+
+
+def create_series(n_steps=400):
+    first = np.random.normal(0.0, 1.0, (n_steps // 2, 1))
+    second = np.random.normal(3.0, 1.0, (n_steps - n_steps // 2, 1))
+    return np.concatenate([first, second], axis=0)
+
+
+def main():
+    series = create_series()
+    model = AnomalyTransformerAE(win_size=20, enc_in=1, d_model=8, n_heads=1,
+                                 e_layers=1, d_ff=8, latent_dim=4, replay_size=200)
+    tensor_series = torch.tensor(series, dtype=torch.float32)
+    windows = [tensor_series[i:i + model.win_size] for i in range(len(tensor_series) - model.win_size + 1)]
+    data = torch.stack(windows)
+    loader = DataLoader(TensorDataset(data, torch.zeros(len(data))), batch_size=1)
+    with torch.no_grad():
+        for batch, _ in loader:
+            model(batch)
+
+    dataset = ZBankDataset(model.z_bank)
+    ae = ZBankAutoencoder(latent_dim=4, enc_in=1, win_size=20)
+    train_autoencoder(ae, dataset, epochs=10, batch_size=16)
+
+    plot_reconstruction_tsne(ae, dataset, save_path="recon_tsne.png")
+    plot_reconstruction_pca(ae, dataset, save_path="recon_pca.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_zbank_autoencoder.py
+++ b/tests/test_zbank_autoencoder.py
@@ -1,0 +1,27 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
+
+from utils.zbank_autoencoder import ZBankAutoencoder, ZBankDataset, train_autoencoder
+from model.transformer_ae import AnomalyTransformerAE
+
+
+def test_autoencoder_training():
+    model = AnomalyTransformerAE(
+        win_size=4,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+    )
+    dummy = torch.zeros(1, 4, 1)
+    for _ in range(3):
+        model(dummy)
+    dataset = ZBankDataset(model.z_bank)
+    ae = ZBankAutoencoder(latent_dim=2, enc_in=1, win_size=4)
+    train_autoencoder(ae, dataset, epochs=1, batch_size=1)
+    out = ae(dataset[0][0].unsqueeze(0))
+    assert out.shape == (1, 4, 1)

--- a/utils/zbank_autoencoder.py
+++ b/utils/zbank_autoencoder.py
@@ -1,0 +1,74 @@
+from typing import Sequence
+
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataset, DataLoader
+
+
+class ZBankDataset(Dataset):
+    """Dataset exposing ``(z, x)`` pairs stored in a model's ``z_bank``."""
+
+    def __init__(self, z_bank: Sequence[dict]):
+        self.z_bank = list(z_bank)
+
+    def __len__(self) -> int:
+        return len(self.z_bank)
+
+    def __getitem__(self, idx: int):
+        entry = self.z_bank[idx]
+        return entry["z"].float(), entry["x"].float()
+
+
+class SimpleDecoder(nn.Module):
+    """Small MLP that maps latent vectors to reconstructions."""
+
+    def __init__(self, latent_dim: int, enc_in: int, win_size: int, hidden: int = 64):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(latent_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, enc_in),
+        )
+        self.win_size = win_size
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        # z: [B, L, latent_dim]
+        b, l, d = z.size()
+        out = self.net(z.view(b * l, d))
+        return out.view(b, l, -1)
+
+
+class ZBankAutoencoder(nn.Module):
+    """Autoencoder dedicated to reconstructing windows from ``z_bank`` latents."""
+
+    def __init__(self, latent_dim: int, enc_in: int, win_size: int, hidden: int = 64):
+        super().__init__()
+        self.decoder = SimpleDecoder(latent_dim, enc_in, win_size, hidden)
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:  # pragma: no cover - simple forward
+        return self.decoder(z)
+
+
+def train_autoencoder(
+    model: ZBankAutoencoder,
+    dataset: ZBankDataset,
+    *,
+    epochs: int = 5,
+    lr: float = 1e-3,
+    batch_size: int = 32,
+) -> None:
+    """Train ``model`` on ``dataset``."""
+
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    optim = torch.optim.Adam(model.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+    model.train()
+    for _ in range(epochs):  # pragma: no cover - simple loop
+        for z, x in loader:
+            recon = model(z)
+            loss = loss_fn(recon, x)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+
+


### PR DESCRIPTION
## Summary
- add ZBankAutoencoder class and training helpers
- extend analysis tools with reconstruction visualization helpers
- provide demo script for training autoencoder on z_bank
- document demo usage in README
- test that the autoencoder can train

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867668d5308832398484c1bed6ebad0