### PR TITLE
Add autoencoder reconstruction visualization

### DIFF
--- a/scripts/zbank_autoencoder_demo.py
+++ b/scripts/zbank_autoencoder_demo.py
@@ -26,7 +26,11 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from model.transformer_ae import AnomalyTransformerAE
 from utils.zbank_autoencoder import ZBankAutoencoder, ZBankDataset, train_autoencoder
-from utils.analysis_tools import plot_reconstruction_tsne, plot_reconstruction_pca
+from utils.analysis_tools import (
+    plot_reconstruction_tsne,
+    plot_reconstruction_pca,
+    plot_autoencoder_vs_series,
+)
 
 
 def create_series(n_steps=400):
@@ -53,6 +57,16 @@ def main():
 
     plot_reconstruction_tsne(ae, dataset, save_path="recon_tsne.png")
     plot_reconstruction_pca(ae, dataset, save_path="recon_pca.png")
+    # Visualize a portion of the original series against the autoencoder
+    # reconstruction to qualitatively assess performance
+    plot_autoencoder_vs_series(
+        ae,
+        dataset,
+        series.squeeze(),
+        start=0,
+        end=200,
+        save_path="recon_vs_series.png",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_zbank_autoencoder.py
+++ b/tests/test_zbank_autoencoder.py
@@ -5,6 +5,7 @@ torch = pytest.importorskip("torch")
 
 from utils.zbank_autoencoder import ZBankAutoencoder, ZBankDataset, train_autoencoder
 from model.transformer_ae import AnomalyTransformerAE
+from utils.analysis_tools import plot_autoencoder_vs_series
 
 
 def test_autoencoder_training():
@@ -25,3 +26,31 @@ def test_autoencoder_training():
     train_autoencoder(ae, dataset, epochs=1, batch_size=1)
     out = ae(dataset[0][0].unsqueeze(0))
     assert out.shape == (1, 4, 1)
+
+
+def test_plot_autoencoder_vs_series(tmp_path):
+    series = np.sin(np.linspace(0, 3.14, 40))
+    model = AnomalyTransformerAE(
+        win_size=10,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+    )
+    tensor_series = torch.tensor(series, dtype=torch.float32).unsqueeze(-1)
+    windows = [tensor_series[i : i + model.win_size] for i in range(len(series) - model.win_size + 1)]
+    data = torch.stack(windows)
+    loader = torch.utils.data.DataLoader(
+        torch.utils.data.TensorDataset(data, torch.zeros(len(data))), batch_size=1
+    )
+    with torch.no_grad():
+        for batch, _ in loader:
+            model(batch)
+    dataset = ZBankDataset(model.z_bank)
+    ae = ZBankAutoencoder(latent_dim=2, enc_in=1, win_size=10)
+    train_autoencoder(ae, dataset, epochs=1, batch_size=1)
+    out = tmp_path / "ae_vs_series.png"
+    plot_autoencoder_vs_series(ae, dataset, series, end=20, save_path=str(out))
+    assert out.exists() and out.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add `plot_autoencoder_vs_series` helper to compare reconstructions with original series
- call new helper in `zbank_autoencoder_demo.py`
- test plotting of autoencoder reconstructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6cb62d948323a2a477dfd9c2e577