### PR TITLE
Add raw data visualization utilities

### DIFF
--- a/tests/test_raw_viz.py
+++ b/tests/test_raw_viz.py
@@ -1,0 +1,21 @@
+import pytest
+
+np = pytest.importorskip("numpy")
+matplotlib = pytest.importorskip("matplotlib")
+
+from utils.analysis_tools import plot_feature_distribution_by_segment, plot_rolling_stats
+
+
+def test_plot_feature_distribution(tmp_path):
+    data = np.random.randn(100, 2)
+    segments = [(0, 50), (50, 100)]
+    out = tmp_path / "feature_dist.png"
+    plot_feature_distribution_by_segment(data, segments, feature=0, save_path=str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_plot_rolling_stats(tmp_path):
+    data = np.random.randn(100)
+    out = tmp_path / "rolling.png"
+    plot_rolling_stats(data, window=10, save_path=str(out))
+    assert out.exists() and out.stat().st_size > 0

--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -445,3 +445,77 @@ def plot_autoencoder_vs_series(
     os.makedirs(os.path.dirname(save_path) or ".", exist_ok=True)
     plt.savefig(save_path)
     plt.close()
+
+# New functions for raw data visualization
+
+def plot_feature_distribution_by_segment(data, segments, feature=0, save_path="feature_dist.png"):
+    """Boxplot showing how a raw feature's distribution changes across segments.
+
+    Parameters
+    ----------
+    data : array-like of shape (time, features) or (time,)
+        Raw sequence to analyze.
+    segments : list of tuple(int, int)
+        Each ``(start, end)`` pair defines a slice ``data[start:end]``.
+    feature : int, optional
+        Index of the feature to visualize when ``data`` is 2D.
+    save_path : str, optional
+        Location where the figure will be saved.
+    """
+    _ensure_deps()
+    data = np.asarray(data)
+    if data.ndim == 1:
+        data = data[:, None]
+    seg_data = []
+    valid_labels = []
+    for start, end in segments:
+        start = max(0, start)
+        end = min(len(data), end)
+        if start >= end:
+            continue
+        seg_data.append(data[start:end, feature])
+        valid_labels.append(f"{start}-{end}")
+    if not seg_data:
+        raise ValueError("No valid segments provided")
+    plt.figure()
+    plt.boxplot(seg_data, labels=valid_labels, showfliers=False)
+    plt.xlabel("Segment")
+    plt.ylabel(f"Feature {feature}")
+    plt.title("Feature Distribution by Segment")
+    plt.tight_layout()
+    os.makedirs(os.path.dirname(save_path) or ".", exist_ok=True)
+    plt.savefig(save_path)
+    plt.close()
+
+
+def plot_rolling_stats(data, feature=0, window=50, save_path="rolling_stats.png"):
+    """Plot rolling mean, std, and min-max range of a raw feature."""
+    _ensure_deps()
+    data = np.asarray(data)
+    if data.ndim == 1:
+        series = data.astype(float)
+    else:
+        series = data[:, feature].astype(float)
+    means = []
+    stds = []
+    mins = []
+    maxs = []
+    for i in range(len(series)):
+        start = max(0, i - window + 1)
+        win = series[start : i + 1]
+        means.append(win.mean())
+        stds.append(win.std())
+        mins.append(win.min())
+        maxs.append(win.max())
+    x = np.arange(len(series))
+    plt.figure()
+    plt.plot(x, means, label="mean")
+    plt.fill_between(x, mins, maxs, alpha=0.2, label="min-max")
+    plt.plot(x, stds, label="std")
+    plt.xlabel("Time")
+    plt.title("Rolling Statistics")
+    plt.legend()
+    plt.tight_layout()
+    os.makedirs(os.path.dirname(save_path) or ".", exist_ok=True)
+    plt.savefig(save_path)
+    plt.close()


### PR DESCRIPTION
## Summary
- add `plot_feature_distribution_by_segment` and `plot_rolling_stats` for raw data exploration
- test new visualization helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686aac83cbec8323b66304bb69bfb87a