### PR TITLE
Fix syntax error in efficiency plots

### DIFF
--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -521,7 +521,6 @@ def plot_rolling_stats(series, *, window=10, save_path="rolling_stats.png"):
     plt.close()
 
 
-def plot_memory_usage_curve(steps, continual_mem, batch_mem, save_path=None):
 def plot_memory_usage_curve(steps, continual_mem, batch_mem, save_path="memory_usage.png"):
     """Plot memory usage for continual vs batch learning over time."""
     _ensure_deps()
@@ -545,7 +544,6 @@ def plot_memory_usage_curve(steps, continual_mem, batch_mem, save_path="memory_u
     plt.close()
 
 
-def plot_parameter_update_efficiency(param_counts, performance, *, labels=None, save_path=None):
 def plot_parameter_update_efficiency(param_counts, performance, *, labels=None, save_path="param_efficiency.png"):
     """Plot model performance as a function of updated parameters."""
     _ensure_deps()
@@ -569,7 +567,6 @@ def plot_parameter_update_efficiency(param_counts, performance, *, labels=None, 
     plt.close()
 
 
-def plot_latency_vs_model_size(model_sizes, latencies, *, labels=None, save_path=None):
 def plot_latency_vs_model_size(model_sizes, latencies, *, labels=None, save_path="latency_vs_size.png"):
     """Plot inference latency as a function of model size."""
     _ensure_deps()


### PR DESCRIPTION
## Summary
- remove duplicate function definitions at the end of `analysis_tools.py`

## Testing
- `pytest -q`
- `python -m py_compile utils/analysis_tools.py`

------
https://chatgpt.com/codex/tasks/task_e_686b760fc6088323aecda421cca03caf