### PR TITLE
Enhance zbank autoencoder demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ qualitatively inspecting continual learning behavior.
   ```bash
   python -m scripts.zbank_autoencoder_demo
   ```
+  You can supply `--load_model path/to/checkpoint.pth` to build the
+  `z_bank` from pretrained weights and `--ae_epochs` to control how long the
+  lightweight autoencoder trains.
 
 - `scripts/visualize_dataset_distribution.py` contrasts the training and test
   splits of the benchmark datasets (SMD, SMAP, MSL, PSM) using


### PR DESCRIPTION
## Summary
- allow loading a checkpoint before building the latent `z_bank`
- let user specify the number of AE training epochs
- document new options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686baa634b948323b20350150a4e8cd1