### PR TITLE
Enhance zbank autoencoder demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,23 @@ qualitatively inspecting continual learning behavior.
   ```bash
   python -m scripts.zbank_autoencoder_demo
   ```
+  You can supply `--load_model path/to/checkpoint.pth` to build the
+  `z_bank` from pretrained weights and `--ae_epochs` to control how long the
+  lightweight autoencoder trains.
+
+- `scripts/raw_autoencoder_demo.py` trains an encoder+decoder autoencoder
+  directly on windowed time series without relying on a `z_bank`. Usage:
+
+  ```bash
+  python -m scripts.raw_autoencoder_demo
+  ```
+  Adjust `--epochs`, `--latent_dim`, and other arguments to explore how well a
+  simple AE reconstructs the data. The demo now saves `latents.npy`,
+  `hidden.npy`, and `recon_errors.npy` for inspection. It also plots
+  `latent_tsne.png`, `latent_pca.png`, `hidden_tsne.png`, and `hidden_pca.png`
+  showing the encoder and decoder representations. The window with the largest
+  reconstruction error is stored in `worst_window.npy` and its index is printed
+  to the console.
 
 - `scripts/visualize_dataset_distribution.py` contrasts the training and test
   splits of the benchmark datasets (SMD, SMAP, MSL, PSM) using

--- a/scripts/raw_autoencoder_demo.py
+++ b/scripts/raw_autoencoder_demo.py
@@ -1,0 +1,119 @@
+"""Train a simple autoencoder directly on raw time-series windows."""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+missing = []
+for _mod in ["numpy", "torch", "sklearn", "matplotlib"]:
+    try:
+        globals()[_mod] = __import__(_mod)
+    except ImportError:
+        missing.append(_mod)
+if missing:
+    raise SystemExit(
+        "Missing required packages: "
+        + ", ".join(missing)
+        + ". Install them with 'pip install -r requirements-demo.txt'"
+    )
+
+import numpy as np
+import torch
+
+from data_factory.data_loader import get_loader_segment
+from utils.window_autoencoder import (
+    WindowDataset,
+    BasicWindowAutoencoder,
+    train_window_autoencoder,
+    collect_autoencoder_details,
+)
+from utils.analysis_tools import (
+    plot_reconstruction_tsne,
+    plot_reconstruction_pca,
+    plot_autoencoder_vs_series,
+    plot_vector_projection,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train AE directly on windows")
+    parser.add_argument("--dataset", type=str, default="SMD", help="dataset name")
+    parser.add_argument("--data_path", type=str, default="dataset/SMD")
+    parser.add_argument("--win_size", type=int, default=100)
+    parser.add_argument("--latent_dim", type=int, default=8)
+    parser.add_argument("--epochs", type=int, default=10)
+    args = parser.parse_args()
+
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    out_dir = os.path.join("outputs", args.dataset.lower(), f"ws{args.win_size}", timestamp)
+    os.makedirs(out_dir, exist_ok=True)
+
+    loader = get_loader_segment(
+        args.data_path,
+        batch_size=1,
+        win_size=args.win_size,
+        step=1,
+        mode="train",
+        dataset=args.dataset,
+    )
+    ds = loader.dataset
+    enc_in = ds.train.shape[1]
+
+    dataset = WindowDataset(ds)
+    ae = BasicWindowAutoencoder(enc_in=enc_in, latent_dim=args.latent_dim)
+    train_window_autoencoder(ae, dataset, epochs=args.epochs, batch_size=16)
+
+    plot_reconstruction_tsne(ae, dataset, save_path=os.path.join(out_dir, "recon_tsne.png"))
+    plot_reconstruction_pca(ae, dataset, save_path=os.path.join(out_dir, "recon_pca.png"))
+    series = ds.train[:, 0]
+    plot_autoencoder_vs_series(
+        ae,
+        dataset,
+        series,
+        start=0,
+        end=min(200, len(series)),
+        save_path=os.path.join(out_dir, "recon_vs_series.png"),
+    )
+
+    latents, hidden, errors = collect_autoencoder_details(ae, dataset)
+    np.save(os.path.join(out_dir, "latents.npy"), latents)
+    np.save(os.path.join(out_dir, "hidden.npy"), hidden)
+    np.save(os.path.join(out_dir, "recon_errors.npy"), errors)
+
+    worst_idx = int(errors.argmax())
+    np.save(os.path.join(out_dir, "worst_window.npy"), dataset[worst_idx][0].numpy())
+    print(f"Worst reconstruction at index {worst_idx}")
+
+    plot_vector_projection(
+        latents,
+        method="tsne",
+        title="Latent t-SNE",
+        save_path=os.path.join(out_dir, "latent_tsne.png"),
+    )
+    plot_vector_projection(
+        latents,
+        method="pca",
+        title="Latent PCA",
+        save_path=os.path.join(out_dir, "latent_pca.png"),
+    )
+    plot_vector_projection(
+        hidden,
+        method="tsne",
+        title="Hidden t-SNE",
+        save_path=os.path.join(out_dir, "hidden_tsne.png"),
+    )
+    plot_vector_projection(
+        hidden,
+        method="pca",
+        title="Hidden PCA",
+        save_path=os.path.join(out_dir, "hidden_pca.png"),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_window_autoencoder.py
+++ b/tests/test_window_autoencoder.py
@@ -1,0 +1,49 @@
+import pytest
+np = pytest.importorskip("numpy")
+torch = pytest.importorskip("torch")
+
+from utils.window_autoencoder import (
+    BasicWindowAutoencoder,
+    WindowDataset,
+    train_window_autoencoder,
+    collect_autoencoder_details,
+)
+from utils.analysis_tools import plot_autoencoder_vs_series, plot_vector_projection
+
+
+def _make_dataset(win_size: int, n_windows: int = 10):
+    series = torch.sin(torch.linspace(0, 3.14, win_size + n_windows - 1)).unsqueeze(-1)
+    windows = [series[i : i + win_size] for i in range(n_windows)]
+    base = torch.utils.data.TensorDataset(torch.stack(windows), torch.zeros(n_windows))
+    return WindowDataset(base), series.squeeze().numpy()
+
+
+def test_window_autoencoder_training():
+    dataset, _ = _make_dataset(win_size=5)
+    ae = BasicWindowAutoencoder(enc_in=1, latent_dim=2)
+    train_window_autoencoder(ae, dataset, epochs=1, batch_size=1)
+    recon, z = ae(dataset[0][0].unsqueeze(0))
+    assert recon.shape == (1, 5, 1)
+    assert z.shape == (1, 5, 2)
+
+
+def test_plot_autoencoder_vs_series(tmp_path):
+    dataset, series = _make_dataset(win_size=8, n_windows=20)
+    ae = BasicWindowAutoencoder(enc_in=1, latent_dim=2)
+    train_window_autoencoder(ae, dataset, epochs=1, batch_size=2)
+    out = tmp_path / "ae_vs_series.png"
+    plot_autoencoder_vs_series(ae, dataset, series, end=20, save_path=str(out))
+    assert out.exists() and out.stat().st_size > 0
+
+
+def test_collect_details_and_projection(tmp_path):
+    dataset, _ = _make_dataset(win_size=6, n_windows=15)
+    ae = BasicWindowAutoencoder(enc_in=1, latent_dim=2)
+    train_window_autoencoder(ae, dataset, epochs=1, batch_size=2)
+    lat, hid, err = collect_autoencoder_details(ae, dataset)
+    assert lat.shape[0] == len(dataset)
+    assert hid.shape[0] == len(dataset)
+    assert err.shape == (len(dataset),)
+    out = tmp_path / "vec.png"
+    plot_vector_projection(lat, save_path=str(out))
+    assert out.exists() and out.stat().st_size > 0

--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -713,3 +713,31 @@ def plot_latency_vs_model_size(model_sizes, latencies, *, labels=None, save_path
     plt.savefig(save_path)
     plt.close()
 
+
+def plot_vector_projection(vectors, *, method="tsne", title=None, save_path="projection.png"):
+    """Project a sequence of vectors with t-SNE or PCA and save a scatter plot."""
+
+    _ensure_deps()
+    arr = np.asarray(vectors)
+    arr = arr.reshape(-1, arr.shape[-1])
+    if method == "tsne":
+        reducer = TSNE(n_components=2, random_state=0)
+    elif method == "pca":
+        reducer = PCA(n_components=2)
+    else:
+        raise ValueError("method must be 'tsne' or 'pca'")
+    reduced = reducer.fit_transform(arr)
+
+    if title is None:
+        title = f"{method.upper()} Projection"
+
+    plt.figure()
+    plt.scatter(reduced[:, 0], reduced[:, 1], s=10)
+    plt.xlabel("Dim 1")
+    plt.ylabel("Dim 2")
+    plt.title(title)
+    plt.tight_layout()
+    os.makedirs(os.path.dirname(save_path) or ".", exist_ok=True)
+    plt.savefig(save_path)
+    plt.close()
+

--- a/utils/window_autoencoder.py
+++ b/utils/window_autoencoder.py
@@ -1,0 +1,102 @@
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataset, DataLoader
+
+import numpy as np
+
+
+class WindowDataset(Dataset):
+    """Wrap a base dataset of windows so that each item returns ``(x, x)``."""
+
+    def __init__(self, base_dataset):
+        self.base = base_dataset
+
+    def __len__(self) -> int:
+        return len(self.base)
+
+    def __getitem__(self, idx: int):
+        x, _ = self.base[idx]
+        return torch.tensor(x, dtype=torch.float32), torch.tensor(x, dtype=torch.float32)
+
+
+class BasicWindowAutoencoder(nn.Module):
+    """Simple autoencoder operating on windowed time series."""
+
+    def __init__(self, enc_in: int, latent_dim: int, hidden: int = 64):
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Linear(enc_in, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, latent_dim),
+        )
+        self.decoder = nn.Sequential(
+            nn.Linear(latent_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, enc_in),
+        )
+
+    def forward(self, x: torch.Tensor, *, return_hidden: bool = False):
+        """Return reconstruction and latent vectors.
+
+        When ``return_hidden`` is ``True`` the output also includes the
+        decoder's hidden representation after the first activation layer.
+        """
+
+        # x: [B, L, enc_in]
+        b, l, c = x.size()
+        flat = x.view(b * l, c)
+        z = self.encoder(flat)
+        h = self.decoder[0](z)
+        h = self.decoder[1](h)
+        recon = self.decoder[2](h).view(b, l, c)
+        z = z.view(b, l, -1)
+        if return_hidden:
+            h = h.view(b, l, -1)
+            return recon, z, h
+        return recon, z
+
+
+def train_window_autoencoder(
+    model: BasicWindowAutoencoder,
+    dataset: Dataset,
+    *,
+    epochs: int = 5,
+    lr: float = 1e-3,
+    batch_size: int = 32,
+) -> None:
+    """Train ``model`` on ``dataset``."""
+
+    loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    optim = torch.optim.Adam(model.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+    model.train()
+    for _ in range(epochs):
+        for x, _ in loader:
+            recon, _ = model(x)
+            loss = loss_fn(recon, x)
+            optim.zero_grad()
+            loss.backward()
+            optim.step()
+
+
+def collect_autoencoder_details(model: BasicWindowAutoencoder, dataset: Dataset):
+    """Return latent vectors, decoder hidden states, and per-window MSE."""
+
+    loader = DataLoader(dataset, batch_size=1)
+    latents = []
+    hiddens = []
+    errors = []
+    loss_fn = nn.MSELoss()
+    model.eval()
+    with torch.no_grad():
+        for x, _ in loader:
+            recon, z, h = model(x, return_hidden=True)
+            latents.append(z.squeeze(0).cpu())
+            hiddens.append(h.squeeze(0).cpu())
+            errors.append(loss_fn(recon, x).item())
+
+    latents = torch.stack(latents).numpy()
+    hiddens = torch.stack(hiddens).numpy()
+    errors = np.array(errors)
+    return latents, hiddens, errors
+


### PR DESCRIPTION
## Summary
- allow loading a checkpoint before building the latent `z_bank`
- let user specify the number of AE training epochs
- add script to train an autoencoder directly on windows
- document the new demo in README
- add latent and hidden-layer analysis utilities

## Testing
- `pytest -q` *(fails: 10 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686baa634b948323b20350150a4e8cd1