### PR TITLE
Fix autoencoder output handling for reconstruction plots

### DIFF
--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -453,7 +453,9 @@ def plot_autoencoder_vs_series(
     with torch.no_grad():
         for i in range(start, min(end - win_size + 1, len(dataset))):
             z, _ = dataset[i]
-            r = autoencoder(z.unsqueeze(0)).squeeze(0).cpu().numpy()[:, 0]
+            # ``BasicWindowAutoencoder`` returns a tuple ``(recon, latents)`` by
+            # default. Extract the reconstruction before squeezing.
+            r = autoencoder(z.unsqueeze(0))[0].squeeze(0).cpu().numpy()[:, 0]
             idx_start = i - start
             idx_end = idx_start + win_size
             if idx_end > max_len:


### PR DESCRIPTION
## Summary
- handle tuple output from `BasicWindowAutoencoder` when creating reconstruction plots

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686bc3893c588323944ff7b04ceb5eff