### PR TITLE
Fix heavy t-SNE plots in inspect mode

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -337,8 +337,11 @@ class Solver(object):
                 plot_reconstruction_per_sample,
             )
 
-            plot_latent_tsne(latents.view(latents.size(0) * latents.size(1), -1).numpy(),
-                             save_path=os.path.join(out_dir, "plot_latent_tsne.png"))
+            plot_latent_tsne(
+                latents.view(latents.size(0) * latents.size(1), -1).numpy(),
+                save_path=os.path.join(out_dir, "plot_latent_tsne.png"),
+                max_points=2000,
+            )
             plot_latent_pca(latents.view(latents.size(0) * latents.size(1), -1).numpy(),
                             save_path=os.path.join(out_dir, "plot_latent_pca.png"))
             plot_error_curve(errors.numpy(),

--- a/utils/analysis_tools.py
+++ b/utils/analysis_tools.py
@@ -147,9 +147,17 @@ def _scatter_projection(orig_latents, replay_latents, reduced, title, save_path)
     plt.close()
 
 
-def plot_latent_tsne(latents, save_path="plot_latent_tsne.png"):
-    """Visualize latent vectors using t-SNE."""
+def plot_latent_tsne(latents, save_path="plot_latent_tsne.png", max_points=2000):
+    """Visualize latent vectors using t-SNE.
+
+    When ``latents`` contains more than ``max_points`` rows, a random subset
+    of that many vectors is used to avoid excessive computation.
+    """
     _ensure_deps()
+    latents = np.asarray(latents)
+    if max_points is not None and len(latents) > max_points:
+        idx = np.random.choice(len(latents), max_points, replace=False)
+        latents = latents[idx]
     reduced = TSNE(n_components=2, random_state=0).fit_transform(latents)
     plt.figure()
     plt.scatter(reduced[:, 0], reduced[:, 1], s=10)


### PR DESCRIPTION
## Summary
- subsample latent vectors in `plot_latent_tsne`
- pass sampling parameter from `collect_debug_info`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686be60ebef48323a1c17d4824620e00