### PR TITLE
Enhance decoder and training options

### DIFF
--- a/incremental_experiment.py
+++ b/incremental_experiment.py
@@ -97,9 +97,15 @@ def main():
                         help='freeze encoder after this many steps')
     parser.add_argument('--ema_decay', type=float, default=None,
                         help='EMA decay for encoder stabilization')
-    parser.add_argument('--decoder_type', type=str, default='mlp',
+    parser.add_argument('--latent_noise_std', type=float, default=0.0,
+                        help='stddev of noise added to latent vectors')
+    parser.add_argument('--decoder_type', type=str, default='attention',
                         choices=['mlp', 'rnn', 'attention'],
                         help='decoder architecture')
+    parser.add_argument('--replay_consistency_weight', type=float, default=0.0,
+                        help='weight for replay consistency loss term')
+    parser.add_argument('--high_freq_weight', type=float, default=0.0,
+                        help='weight for high frequency reconstruction loss')
     parser.add_argument('--model_tag', type=str, default='dynamic')
     parser.add_argument(
         '--cpd_penalty',

--- a/solver.py
+++ b/solver.py
@@ -77,7 +77,10 @@ class Solver(object):
         'store_mu': False,
         'freeze_after': None,
         'ema_decay': None,
-        'decoder_type': 'mlp',
+        'decoder_type': 'attention',
+        'latent_noise_std': 0.0,
+        'replay_consistency_weight': 0.0,
+        'high_freq_weight': 0.0,
         'anomaly_ratio': 1.0,
         'cpd_penalty': 20,
         'min_cpd_gap': 30,
@@ -133,7 +136,9 @@ class Solver(object):
                 replay_horizon=getattr(self, 'replay_horizon', None),
                 freeze_after=getattr(self, 'freeze_after', None),
                 ema_decay=getattr(self, 'ema_decay', None),
-                decoder_type=getattr(self, 'decoder_type', 'mlp'),
+                decoder_type=getattr(self, 'decoder_type', 'attention'),
+                latent_noise_std=getattr(self, 'latent_noise_std', 0.0),
+                high_freq_weight=getattr(self, 'high_freq_weight', 0.0),
             )
         else:
             self.model = AnomalyTransformer(
@@ -402,6 +407,9 @@ class Solver(object):
                         input,
                         cpd_penalty=getattr(self, 'cpd_penalty', 20),
                         min_gap=getattr(self, 'min_cpd_gap', 30),
+                        replay_consistency_weight=getattr(
+                            self, 'replay_consistency_weight', 0.0
+                        ),
                     )
                     loss1_list.append(loss)
                     if updated:

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -113,3 +113,31 @@ def test_replay_consistency_loss():
     after = model.decoder(model.z_bank[0]["z"].unsqueeze(0))
     target = model.z_bank[0]["x"].unsqueeze(0)
     assert F.mse_loss(after, target) < F.mse_loss(before, target)
+
+
+def test_high_freq_loss():
+    base = AnomalyTransformerAE(
+        win_size=4,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+    )
+    with_high = AnomalyTransformerAE(
+        win_size=4,
+        enc_in=1,
+        d_model=4,
+        n_heads=1,
+        e_layers=1,
+        d_ff=4,
+        latent_dim=2,
+        high_freq_weight=1.0,
+    )
+    x = torch.zeros(1, 4, 1)
+    recon = torch.zeros_like(x)
+    recon[:, 2, 0] = 1.0
+    loss_base = base.loss_function(recon, x)
+    loss_hf = with_high.loss_function(recon, x)
+    assert loss_hf > loss_base


### PR DESCRIPTION
## Summary
- expose extra training options in `incremental_experiment`
- default to attention decoder and support new parameters in `Solver`
- implement high frequency loss in `AnomalyTransformerAE`
- adjust model builder and replay training
- extend unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bf71010608323b0b6631a94c453a5