### PR TITLE
Return indices from loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,10 @@ approach leverages the VAE branch to mitigate concept drift.
 - `--store_mu`: store `(mu, logvar)` pairs instead of sampled `z` for replay.
 - `--freeze_after`: freeze the encoder after this many updates (default `None`).
 - `--ema_decay`: apply EMA to encoder weights with this decay (default `None`).
-- `--decoder_type`: choose decoder architecture: `mlp`, `rnn`, or `attention`.
+- `--decoder_type`: choose decoder architecture: `conditional`, `mlp`, `rnn`, or `attention` (default `conditional`).
+- `--latent_noise_std`: standard deviation of Gaussian noise added to latent vectors during training (default `0`).
+- `--replay_consistency_weight`: strength of the auxiliary loss ensuring stored latents decode consistently (default `0`).
+- `--high_freq_weight`: emphasize high-frequency reconstruction errors with this weight (default `0`).
 - `--min_cpd_gap`: minimum separation between detected change points (default
   `30`).
 - `--cpd_log_interval`: evaluate and print metrics only after this many CPD

--- a/data_factory/data_loader.py
+++ b/data_factory/data_loader.py
@@ -57,18 +57,36 @@ class PSMSegLoader(object):
             return (self.test.shape[0] - self.win_size) // self.win_size + 1
 
     def __getitem__(self, index):
-        index = index * self.step
+        pos = index * self.step
         if self.mode == "train":
-            return np.float32(self.train[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
+            return (
+                np.float32(self.train[pos : pos + self.win_size]),
+                np.float32(self.test_labels[0 : self.win_size]),
+                pos,
+            )
         elif (self.mode == 'val'):
-            return np.float32(self.val[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
+            return (
+                np.float32(self.val[pos : pos + self.win_size]),
+                np.float32(self.test_labels[0 : self.win_size]),
+                pos,
+            )
         elif (self.mode == 'test'):
-            return np.float32(self.test[index:index + self.win_size]), np.float32(
-                self.test_labels[index:index + self.win_size])
+            return (
+                np.float32(self.test[pos : pos + self.win_size]),
+                np.float32(self.test_labels[pos : pos + self.win_size]),
+                pos,
+            )
         else:
-            return np.float32(self.test[
-                              index // self.step * self.win_size:index // self.step * self.win_size + self.win_size]), np.float32(
-                self.test_labels[index // self.step * self.win_size:index // self.step * self.win_size + self.win_size])
+            pos = index // self.step * self.win_size
+            return (
+                np.float32(
+                    self.test[pos : pos + self.win_size]
+                ),
+                np.float32(
+                    self.test_labels[pos : pos + self.win_size]
+                ),
+                pos,
+            )
 
 
 class MSLSegLoader(object):
@@ -102,18 +120,36 @@ class MSLSegLoader(object):
             return (self.test.shape[0] - self.win_size) // self.win_size + 1
 
     def __getitem__(self, index):
-        index = index * self.step
+        pos = index * self.step
         if self.mode == "train":
-            return np.float32(self.train[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
+            return (
+                np.float32(self.train[pos : pos + self.win_size]),
+                np.float32(self.test_labels[0 : self.win_size]),
+                pos,
+            )
         elif (self.mode == 'val'):
-            return np.float32(self.val[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
+            return (
+                np.float32(self.val[pos : pos + self.win_size]),
+                np.float32(self.test_labels[0 : self.win_size]),
+                pos,
+            )
         elif (self.mode == 'test'):
-            return np.float32(self.test[index:index + self.win_size]), np.float32(
-                self.test_labels[index:index + self.win_size])
+            return (
+                np.float32(self.test[pos : pos + self.win_size]),
+                np.float32(self.test_labels[pos : pos + self.win_size]),
+                pos,
+            )
         else:
-            return np.float32(self.test[
-                              index // self.step * self.win_size:index // self.step * self.win_size + self.win_size]), np.float32(
-                self.test_labels[index // self.step * self.win_size:index // self.step * self.win_size + self.win_size])
+            pos = index // self.step * self.win_size
+            return (
+                np.float32(
+                    self.test[pos : pos + self.win_size]
+                ),
+                np.float32(
+                    self.test_labels[pos : pos + self.win_size]
+                ),
+                pos,
+            )
 
 
 class SMAPSegLoader(object):
@@ -147,18 +183,36 @@ class SMAPSegLoader(object):
             return (self.test.shape[0] - self.win_size) // self.win_size + 1
 
     def __getitem__(self, index):
-        index = index * self.step
+        pos = index * self.step
         if self.mode == "train":
-            return np.float32(self.train[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
+            return (
+                np.float32(self.train[pos : pos + self.win_size]),
+                np.float32(self.test_labels[0 : self.win_size]),
+                pos,
+            )
         elif (self.mode == 'val'):
-            return np.float32(self.val[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
+            return (
+                np.float32(self.val[pos : pos + self.win_size]),
+                np.float32(self.test_labels[0 : self.win_size]),
+                pos,
+            )
         elif (self.mode == 'test'):
-            return np.float32(self.test[index:index + self.win_size]), np.float32(
-                self.test_labels[index:index + self.win_size])
+            return (
+                np.float32(self.test[pos : pos + self.win_size]),
+                np.float32(self.test_labels[pos : pos + self.win_size]),
+                pos,
+            )
         else:
-            return np.float32(self.test[
-                              index // self.step * self.win_size:index // self.step * self.win_size + self.win_size]), np.float32(
-                self.test_labels[index // self.step * self.win_size:index // self.step * self.win_size + self.win_size])
+            pos = index // self.step * self.win_size
+            return (
+                np.float32(
+                    self.test[pos : pos + self.win_size]
+                ),
+                np.float32(
+                    self.test_labels[pos : pos + self.win_size]
+                ),
+                pos,
+            )
 
 
 class SMDSegLoader(object):
@@ -191,18 +245,36 @@ class SMDSegLoader(object):
             return (self.test.shape[0] - self.win_size) // self.win_size + 1
 
     def __getitem__(self, index):
-        index = index * self.step
+        pos = index * self.step
         if self.mode == "train":
-            return np.float32(self.train[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
+            return (
+                np.float32(self.train[pos : pos + self.win_size]),
+                np.float32(self.test_labels[0 : self.win_size]),
+                pos,
+            )
         elif (self.mode == 'val'):
-            return np.float32(self.val[index:index + self.win_size]), np.float32(self.test_labels[0:self.win_size])
+            return (
+                np.float32(self.val[pos : pos + self.win_size]),
+                np.float32(self.test_labels[0 : self.win_size]),
+                pos,
+            )
         elif (self.mode == 'test'):
-            return np.float32(self.test[index:index + self.win_size]), np.float32(
-                self.test_labels[index:index + self.win_size])
+            return (
+                np.float32(self.test[pos : pos + self.win_size]),
+                np.float32(self.test_labels[pos : pos + self.win_size]),
+                pos,
+            )
         else:
-            return np.float32(self.test[
-                              index // self.step * self.win_size:index // self.step * self.win_size + self.win_size]), np.float32(
-                self.test_labels[index // self.step * self.win_size:index // self.step * self.win_size + self.win_size])
+            pos = index // self.step * self.win_size
+            return (
+                np.float32(
+                    self.test[pos : pos + self.win_size]
+                ),
+                np.float32(
+                    self.test_labels[pos : pos + self.win_size]
+                ),
+                pos,
+            )
 
 
 def get_loader_segment(data_path, batch_size, win_size=100, step=100, mode='train', dataset='KDD', train_start=0.0, train_end=1.0):

--- a/solver.py
+++ b/solver.py
@@ -151,7 +151,7 @@ class Solver(object):
 
         loss_1 = []
         loss_2 = []
-        for i, (input_data, _) in enumerate(vali_loader):
+        for i, (input_data, _, _) in enumerate(vali_loader):
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
             series_loss = 0.0
@@ -195,7 +195,7 @@ class Solver(object):
 
         # energies on train set
         attens_energy = []
-        for i, (input_data, labels) in enumerate(self.train_loader):
+        for i, (input_data, labels, _) in enumerate(self.train_loader):
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
             loss = torch.mean(criterion(input, output), dim=-1)
@@ -227,7 +227,7 @@ class Solver(object):
         # energies on threshold loader
         attens_energy = []
         test_labels = []
-        for i, (input_data, labels) in enumerate(self.thre_loader):
+        for i, (input_data, labels, _) in enumerate(self.thre_loader):
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
             loss = torch.mean(criterion(input, output), dim=-1)
@@ -390,7 +390,7 @@ class Solver(object):
 
             epoch_time = time.time()
             self.model.train()
-            for i, (input_data, labels) in enumerate(self.train_loader):
+            for i, (input_data, labels, indices) in enumerate(self.train_loader):
 
                 iter_count += 1
                 input = input_data.float().to(self.device)
@@ -400,6 +400,7 @@ class Solver(object):
                         self.model,
                         self.optimizer,
                         input,
+                        indices=indices,
                         cpd_penalty=getattr(self, 'cpd_penalty', 20),
                         min_gap=getattr(self, 'min_cpd_gap', 30),
                     )
@@ -561,7 +562,7 @@ class Solver(object):
 
         # (1) stastic on the train set
         attens_energy = []
-        for i, (input_data, labels) in enumerate(self.train_loader):
+        for i, (input_data, labels, _) in enumerate(self.train_loader):
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
             loss = torch.mean(criterion(input, output), dim=-1)
@@ -595,7 +596,7 @@ class Solver(object):
 
         # (2) find the threshold
         attens_energy = []
-        for i, (input_data, labels) in enumerate(self.thre_loader):
+        for i, (input_data, labels, _) in enumerate(self.thre_loader):
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
 
@@ -635,7 +636,7 @@ class Solver(object):
         # (3) evaluation on the test set
         test_labels = []
         attens_energy = []
-        for i, (input_data, labels) in enumerate(self.thre_loader):
+        for i, (input_data, labels, _) in enumerate(self.thre_loader):
             input = input_data.float().to(self.device)
             output, series, prior, _ = self.model(input)
 


### PR DESCRIPTION
## Summary
- data loaders now return sample index so we can track it
- update solver to pass these indices and handle three-element batches
- extend AnomalyTransformerAE and training util with index support
- chronologically decode replay by stored position
- document new options in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ceae9e1848323a7ead405525387d6