### PR TITLE
Restore ae_epochs option in zbank_autoencoder_demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ qualitatively inspecting continual learning behavior.
   ```bash
   python -m scripts.zbank_autoencoder_demo
   ```
+  You can supply `--load_model path/to/checkpoint.pth` to build the
+  `z_bank` from pretrained weights and `--ae_epochs` to control how long the
+  lightweight autoencoder trains.
 
 - `scripts/visualize_dataset_distribution.py` contrasts the training and test
   splits of the benchmark datasets (SMD, SMAP, MSL, PSM) using

--- a/scripts/zbank_autoencoder_demo.py
+++ b/scripts/zbank_autoencoder_demo.py
@@ -28,7 +28,11 @@ from torch.utils.data import DataLoader
 from data_factory.data_loader import get_loader_segment
 
 from model.transformer_ae import AnomalyTransformerAE
-from utils.zbank_autoencoder import ZBankAutoencoder, ZBankDataset, train_autoencoder
+from utils.zbank_autoencoder import (
+    ZBankAutoencoder,
+    ZBankDataset,
+    train_autoencoder,
+)
 from utils.analysis_tools import (
     plot_reconstruction_tsne,
     plot_reconstruction_pca,
@@ -38,6 +42,15 @@ from utils.analysis_tools import (
 
 def _load_z_bank(path: str):
     return torch.load(path)
+
+
+def _load_model_weights(model: AnomalyTransformerAE, path: str) -> None:
+    if os.path.isfile(path):
+        state = torch.load(path, map_location="cpu")
+        model.load_state_dict(state)
+        print(f"Loaded pretrained model from {path}")
+    else:
+        raise FileNotFoundError(path)
 
 
 def _save_z_bank(z_bank, path: str) -> None:
@@ -59,6 +72,8 @@ def main() -> None:
     parser.add_argument("--win_size", type=int, default=100, help="window size")
     parser.add_argument("--latent_dim", type=int, default=4, help="latent dimension")
     parser.add_argument("--z_bank", type=str, default=None, help="optional path to load/save z_bank")
+    parser.add_argument("--load_model", type=str, default=None, help="pretrained model checkpoint")
+    parser.add_argument("--ae_epochs", type=int, default=10, help="autoencoder training epochs")
     args = parser.parse_args()
 
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -87,6 +102,9 @@ def main() -> None:
         replay_size=200,
     )
 
+    if args.load_model:
+        _load_model_weights(model, args.load_model)
+
     if args.z_bank and os.path.isfile(args.z_bank):
         model.z_bank = _load_z_bank(args.z_bank)
     else:
@@ -98,7 +116,7 @@ def main() -> None:
 
     dataset = ZBankDataset(model.z_bank)
     ae = ZBankAutoencoder(latent_dim=args.latent_dim, enc_in=enc_in, win_size=args.win_size)
-    train_autoencoder(ae, dataset, epochs=10, batch_size=16)
+    train_autoencoder(ae, dataset, epochs=args.ae_epochs, batch_size=16)
 
     plot_reconstruction_tsne(ae, dataset, save_path=os.path.join(out_dir, "recon_tsne.png"))
     plot_reconstruction_pca(ae, dataset, save_path=os.path.join(out_dir, "recon_pca.png"))


### PR DESCRIPTION
## Summary
- add `--load_model` and `--ae_epochs` back to the zbank autoencoder demo
- document optional arguments in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf10d62f883239bd0a291d448feae